### PR TITLE
Scope recording to UnityEditor only

### DIFF
--- a/Assets/Vimeo/Scripts/Config/VimeoAuth.cs
+++ b/Assets/Vimeo/Scripts/Config/VimeoAuth.cs
@@ -9,7 +9,12 @@ namespace Vimeo
         public string vimeoToken;
         public bool   saveVimeoToken = true;
         public bool   vimeoSignIn = false;
-        private const string VIMEO_TOKEN_NAME = "vimeo-token-";
+        private const string VIMEO_TOKEN_PREFIX = "vimeo-token-";
+
+        private string GetTokenKey()
+        {
+            return VIMEO_TOKEN_PREFIX + this.GetType().Name + "-" + this.gameObject.scene.name;
+        }
 
         public string GetVimeoToken()
         {
@@ -17,14 +22,13 @@ namespace Vimeo
                 return vimeoToken;
             }
             else {
-                return PlayerPrefs.GetString(VIMEO_TOKEN_NAME + this.gameObject.scene.name);
+                return PlayerPrefs.GetString(GetTokenKey());
             }
         }
 
         public void SetVimeoToken(string token)
         {
-            // Wasn't able to DRY this up - PlayerPrefs started causing seg faults :/
-            string token_name = VIMEO_TOKEN_NAME + this.gameObject.scene.name;
+            string token_name = GetTokenKey();
 
             if (saveVimeoToken) {
                 SetKey(token_name, null);

--- a/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
@@ -34,7 +34,7 @@ namespace Vimeo
                 }
                 GUILayout.EndHorizontal();
 
-                EditorGUILayout.PropertyField(so.FindProperty("saveVimeoToken"), new GUIContent("Save token with scene"));
+                EditorGUILayout.PropertyField(so.FindProperty("saveVimeoToken"), new GUIContent("Save token with object"));
 
                 GUI.backgroundColor = Color.green;
                 if (Authenticated(auth.vimeoToken)) {

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -37,6 +37,11 @@ namespace Vimeo.Player
 
         private void Start()
         {
+            if (!vimeoSignIn) {
+                Debug.LogWarning("You have not signed into the Vimeo Player.");
+                return;
+            }
+
             if (GetVimeoToken() != null) {
                 api = gameObject.AddComponent<VimeoApi>();
                 api.token = GetVimeoToken();

--- a/Assets/Vimeo/Scripts/Recorder/Input/AudioInput.cs
+++ b/Assets/Vimeo/Scripts/Recorder/Input/AudioInput.cs
@@ -1,4 +1,5 @@
 #if UNITY_2018_1_OR_NEWER
+#if UNITY_EDITOR
 
 using UnityEngine;
 using Unity.Collections;
@@ -36,3 +37,4 @@ namespace Vimeo.Recorder
 }
 
 #endif 
+#endif

--- a/Assets/Vimeo/Scripts/Recorder/Input/CameraInput.cs
+++ b/Assets/Vimeo/Scripts/Recorder/Input/CameraInput.cs
@@ -1,4 +1,5 @@
 #if UNITY_2018_1_OR_NEWER
+#if UNITY_EDITOR
 
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -258,4 +259,5 @@ namespace Vimeo.Recorder
     }
 }
 
+#endif
 #endif

--- a/Assets/Vimeo/Scripts/Recorder/Input/ScreenInput.cs
+++ b/Assets/Vimeo/Scripts/Recorder/Input/ScreenInput.cs
@@ -1,4 +1,5 @@
 #if UNITY_2018_1_OR_NEWER
+#if UNITY_EDITOR
 
 using UnityEngine;
 using UnityEditor;
@@ -23,4 +24,5 @@ namespace Vimeo.Recorder
     }
 }
 
+#endif 
 #endif 

--- a/Assets/Vimeo/Scripts/Recorder/Input/VideoInput.cs
+++ b/Assets/Vimeo/Scripts/Recorder/Input/VideoInput.cs
@@ -1,4 +1,5 @@
 #if UNITY_2018_1_OR_NEWER
+#if UNITY_EDITOR
 
 using UnityEngine;
 using UnityEngine.Recorder.Input;
@@ -83,4 +84,5 @@ namespace Vimeo.Recorder
     }
 }
 
+#endif
 #endif

--- a/Assets/Vimeo/Scripts/Recorder/RecorderController.cs
+++ b/Assets/Vimeo/Scripts/Recorder/RecorderController.cs
@@ -1,4 +1,5 @@
 ﻿#if UNITY_2018_1_OR_NEWER
+#if UNITY_EDITOR
 
 using UnityEditor.Media;
 using UnityEngine;
@@ -206,4 +207,5 @@ namespace Vimeo.Recorder {
         }
     }
 }
+#endif
 #endif

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -1,4 +1,6 @@
 ﻿#if UNITY_2018_1_OR_NEWER 
+#if UNITY_EDITOR
+
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -164,4 +166,5 @@ namespace Vimeo.Recorder
     }
 }
 
+#endif
 #endif

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -1,4 +1,5 @@
 ﻿#if UNITY_2018_1_OR_NEWER 
+#if UNITY_EDITOR
 
 using UnityEngine;
 using UnityEditor;
@@ -126,4 +127,5 @@ namespace Vimeo.Recorder
     }
 }
 
+#endif
 #endif

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.1.0b11
+m_EditorVersion: 2018.1.0f2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Download the most recent `.unitypackage` from the [latest releases](https://gith
 # Requirements
 * For recording: 
   * Unity `2018.1` or higher.
+  * Only available in the `UnityEditor` and not standalone builds.
   * Requires a [Vimeo account](https://vimeo.com). 
 * For streaming playback:
   * Unity `5.6.0` or higher.


### PR DESCRIPTION
* Fixes #15 
* There was an issue where signing out of one VimeoPlayer would sign out of the other ones. This disconnects that and now requires you to set a token for each Vimeo object (more work, but less confusing). `Note: for any existing unity projects using the Vimeo object, you will need to sign back in`