### PR TITLE
Creating an event for network errors

### DIFF
--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -73,6 +73,11 @@ namespace Vimeo.Player
                 }
             }
 
+            if (api != null){
+                api.OnError += ApiError;
+                api.OnNetworkError += NetworkError;
+            }
+
             LoadVimeoVideoByUrl(vimeoVideoId);
 
             if (OnLoad != null) OnLoad();
@@ -364,6 +369,16 @@ namespace Vimeo.Player
         private static int SortByQuality(JSONNode q1, JSONNode q2)
         {
             return int.Parse(q2["height"]).CompareTo(int.Parse(q1["height"]));
+        }
+
+        private void ApiError(string response)
+        {
+            Debug.LogError(response);
+        }
+
+        private void NetworkError(string error_message)
+        {
+            Debug.LogError("It seems like you are not connected to the internet or are having connection problems.");
         }
     }
 }

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -115,7 +115,8 @@ namespace Vimeo.Recorder
             UploadProgress("SaveInfoComplete", 1f);
         }
 
-        private void NetworkError(string response){
+        private void NetworkError(string response)
+        {
             Debug.LogError("It seems like you are not connected to the internet, or having connection problems which disables the uploading of the video.");
         }
 

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -30,6 +30,7 @@ namespace Vimeo.Recorder
                 vimeoApi.OnUploadComplete += UploadComplete;
                 vimeoApi.OnUploadProgress += UploadProgress;
                 vimeoApi.OnError          += ApiError;
+                vimeoApi.OnNetworkError   += NetworkError;
 
                 vimeoApi.token = recorder.GetVimeoToken();
             }
@@ -112,6 +113,10 @@ namespace Vimeo.Recorder
             }
 
             UploadProgress("SaveInfoComplete", 1f);
+        }
+
+        private void NetworkError(string response){
+            Debug.LogError("It seems like you are not connected to the internet, or having connection problems which disables the uploading of the video.");
         }
 
         private void ApiError(string response)

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -13,7 +13,7 @@ namespace Vimeo.Recorder
         public event UploadAction OnUploadProgress;
 
         public delegate void RequestAction(string error_message);
-        public event RequestAction OnUploadFail;
+        public event RequestAction OnNetworkError;
 
         [HideInInspector] public VimeoRecorder recorder; // recorder contains all the settings
 
@@ -120,8 +120,8 @@ namespace Vimeo.Recorder
 
         private void NetworkError(string error_message)
         {
-            if (OnUploadFail != null) {
-                OnUploadFail("It seems like you are not connected to the internet or are having connection problems.");
+            if (OnNetworkError != null) {
+                OnNetworkError("It seems like you are not connected to the internet or are having connection problems.");
             }
         }
 
@@ -134,18 +134,18 @@ namespace Vimeo.Recorder
                 for (int i = 0; i < json["invalid_parameters"].Count; i++) {
                     // TODO use .Value
                     if (json["invalid_parameters"][i]["field"].ToString() == "\"privacy.download\"") {
-                        if (OnUploadFail != null) {
-                            OnUploadFail("You must upgrade your Vimeo account in order to access this privacy feature. https://vimeo.com/upgrade");
+                        if (OnNetworkError != null) {
+                            OnNetworkError("You must upgrade your Vimeo account in order to access this privacy feature. https://vimeo.com/upgrade");
                         }
                     }
                     else if (json["invalid_parameters"][i]["field"].ToString() == "\"privacy.view\"") {
-                        if (OnUploadFail != null) {
-                            OnUploadFail("You must upgrade your Vimeo account in order to access this privacy feature. https://vimeo.com/upgrade");
+                        if (OnNetworkError != null) {
+                            OnNetworkError("You must upgrade your Vimeo account in order to access this privacy feature. https://vimeo.com/upgrade");
                         }
                     }
                     else {
-                        if (OnUploadFail != null) {
-                            OnUploadFail(json["invalid_parameters"][i]["field"] + ": " + json["invalid_parameters"][i]["error"]);
+                        if (OnNetworkError != null) {
+                            OnNetworkError(json["invalid_parameters"][i]["field"] + ": " + json["invalid_parameters"][i]["error"]);
                         }
                     }
                 }

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -12,7 +12,7 @@ namespace Vimeo.Recorder
         public delegate void UploadAction(string status, float progress);
         public event UploadAction OnUploadProgress;
 
-        public delegate void RequestAction(string response);
+        public delegate void RequestAction(string error_message);
         public event RequestAction OnUploadFail;
 
         [HideInInspector] public VimeoRecorder recorder; // recorder contains all the settings
@@ -118,10 +118,10 @@ namespace Vimeo.Recorder
             UploadProgress("SaveInfoComplete", 1f);
         }
 
-        private void NetworkError(string response)
+        private void NetworkError(string error_message)
         {
             if (OnUploadFail != null) {
-                OnUploadFail("It seems like you are not connected to the internet, or having connection problems which disables the uploading of the video.");
+                OnUploadFail("It seems like you are not connected to the internet or are having connection problems.");
             }
         }
 

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -72,7 +72,7 @@ namespace Vimeo.Recorder
                 publisher.Init(this);
 
                 publisher.OnUploadProgress += UploadProgress;
-                publisher.OnUploadFail += UploadFail;
+                publisher.OnNetworkError += NetworkError;
             }
             
             publisher.PublishVideo(filePath);
@@ -92,7 +92,7 @@ namespace Vimeo.Recorder
             }
         }
 
-        private void UploadFail(string status){
+        private void NetworkError(string status){
             Debug.LogError(status);
         }
 

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -72,6 +72,7 @@ namespace Vimeo.Recorder
                 publisher.Init(this);
 
                 publisher.OnUploadProgress += UploadProgress;
+                publisher.OnUploadFail += UploadFail;
             }
             
             publisher.PublishVideo(filePath);
@@ -89,6 +90,10 @@ namespace Vimeo.Recorder
                     OnUploadComplete();
                 }
             }
+        }
+
+        private void UploadFail(string status){
+            Debug.LogError(status);
         }
 
         private void Dispose()

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -42,6 +42,7 @@ namespace Vimeo
         public event RequestAction OnUploadComplete;
         public event RequestAction OnPatchComplete;
         public event RequestAction OnError;
+        public event RequestAction OnNetworkError;
 
         public delegate void UploadAction(string status, float progress);
         public event UploadAction OnUploadProgress;
@@ -187,7 +188,9 @@ namespace Vimeo
                 yield return VimeoApi.SendRequest(request);
 
                 if (IsNetworkError(request)) {
-                    Debug.LogError(request.error);
+                    if(OnNetworkError != null){
+                        OnNetworkError(request.error);
+                    }
                 } 
                 else {
                     VimeoTicket ticket = VimeoTicket.CreateFromJSON(request.downloadHandler.text);
@@ -237,8 +240,9 @@ namespace Vimeo
                 uploader = null;
 
                 if (IsNetworkError(request)) {
-                    Debug.Log(request.error);
-                    Debug.Log(request.responseCode);
+                    if (OnNetworkError != null) {
+                        OnNetworkError(request.error);
+                    }
                 } 
                 else {
                     StartCoroutine(VerifyUpload(ticket));

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -188,7 +188,7 @@ namespace Vimeo
                 yield return VimeoApi.SendRequest(request);
 
                 if (IsNetworkError(request)) {
-                    if(OnNetworkError != null){
+                    if (OnNetworkError != null) {
                         OnNetworkError(request.error);
                     }
                 } 

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -339,12 +339,13 @@ namespace Vimeo
                     if (request.responseCode == 401) {
                         Debug.LogError("[VimeoApi] 401 Unauthorized request.");
                     }
-                    if (OnError != null && OnNetworkError != null) {
-                        if (IsNetworkError(request)) {
-                            OnNetworkError(request.error);
-                        } else {
-                            OnError(request.downloadHandler.text);
-                        }
+
+                    if (OnNetworkError != null && IsNetworkError(request)) {
+                        OnNetworkError(request.error);
+                    }
+
+                    if (OnError != null && !IsNetworkError(request)) {
+                        OnError(request.downloadHandler.text);
                     }
                 }
                 else if (OnRequestComplete != null) {

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -339,11 +339,13 @@ namespace Vimeo
                     if (request.responseCode == 401) {
                         Debug.LogError("[VimeoApi] 401 Unauthorized request.");
                     }
-                    else {
-                        JSONNode json = JSON.Parse(request.downloadHandler.text);
-                        Debug.LogError("[VimeoApi] " + request.responseCode + " " + json["error"]);
+                    if (OnError != null && OnNetworkError != null) {
+                        if (IsNetworkError(request)) {
+                            OnNetworkError(request.error);
+                        } else {
+                            OnError(request.downloadHandler.text);
+                        }
                     }
-                    if (OnError != null) OnError(request.downloadHandler.text);
                 }
                 else if (OnRequestComplete != null) {
                     OnRequestComplete(request.downloadHandler.text);


### PR DESCRIPTION
The `VimeoAPI` now implements `OnNetworkError` event which listens to `request.isNetworkError` and prints an error to the console when a network error prevents you from publishing to Vimeo

> Tested on macOS / Unity v2018.1.6f1