### PR TITLE
Decouple record & upload

### DIFF
--- a/Assets/Tests/Play/VimeoRecorderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoRecorderPlayTest.cs
@@ -107,17 +107,11 @@ public class VimeoRecorderPlayTest : TestConfig
         recorder.SignIn(VALID_RECORDING_TOKEN);
         recorder.autoUpload = false;
         recorder.BeginRecording();
-        recorder.OnUploadComplete += UploadComplete;
-    
-        while (!uploaded) {
-            yield return new WaitForSeconds(.25f);
-            elapsed += .25f;
 
-            if (elapsed >= timeout) {
-                recorder.CancelRecording();
-                Assert.Pass("Recorded a video, but did not publish it");
-            }
-        }
+        recorder.OnUploadComplete += UploadComplete;
+        yield return new WaitUntil(()=> !recorder.isRecording);
+        yield return new WaitForSeconds(.25f);
+        Assert.IsFalse(recorder.isUploading, "Recorded a video but did not upload it to Vimeo");
     }
 
     private void UploadComplete()

--- a/Assets/Tests/Play/VimeoRecorderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoRecorderPlayTest.cs
@@ -107,8 +107,17 @@ public class VimeoRecorderPlayTest : TestConfig
         recorder.SignIn(VALID_RECORDING_TOKEN);
         recorder.autoUpload = false;
         recorder.BeginRecording();
+        recorder.OnUploadComplete += UploadComplete;
+    
+        while (!uploaded) {
+            yield return new WaitForSeconds(.25f);
+            elapsed += .25f;
 
-        yield return new WaitForSeconds(.25f);
+            if (elapsed >= timeout) {
+                recorder.CancelRecording();
+                Assert.Pass("Recorded a video, but did not publish it");
+            }
+        }
     }
 
     private void UploadComplete()

--- a/Assets/Tests/Play/VimeoRecorderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoRecorderPlayTest.cs
@@ -99,6 +99,18 @@ public class VimeoRecorderPlayTest : TestConfig
         }
     }
 
+    [UnityTest]
+    public IEnumerator Can_Record_Video_Without_Uploading()
+    {
+        recorder.videoName = "Screen Test " + recorder.videoName;
+        recorder.defaultVideoInput = VideoInputType.Screen;
+        recorder.SignIn(VALID_RECORDING_TOKEN);
+        recorder.autoUpload = false;
+        recorder.BeginRecording();
+
+        yield return new WaitForSeconds(.25f);
+    }
+
     private void UploadComplete()
     {
         uploaded = true;

--- a/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
@@ -102,6 +102,7 @@ namespace Vimeo.Recorder
         public int frameRate = 30;
         public bool recordOnStart = false;
         public bool openInBrowser = true;
+        public bool autoUpload = true;
 
         public string videoName;
         public string videoPermalink;

--- a/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
@@ -108,9 +108,15 @@ namespace Vimeo.Recorder
             if (EditorApplication.isPlaying && recorder.encoderType == EncoderType.MediaEncoder) {
                 if (recorder.isRecording) {
                     GUI.backgroundColor = Color.green;
-
-                    if (GUILayout.Button("Finish & Upload", GUILayout.Height(30))) {
-                        recorder.EndRecording();
+                    
+                    if (recorder.autoUpload) {
+                        if (GUILayout.Button("Finish & Upload", GUILayout.Height(30))) {
+                            recorder.EndRecording();
+                        }
+                    } else {
+                        if (GUILayout.Button("Finish", GUILayout.Height(30))) {
+                            recorder.EndRecording();
+                        }
                     }
 
                     GUI.backgroundColor = Color.red;

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -54,7 +54,7 @@ namespace Vimeo.Recorder
             if (autoUpload) {
                 PublishVideo();
             } else {
-                Debug.Log("[Vimeo] You set autoUpload to false, you can easily use the vimeoPlayer.PublishVideo() to easily trigger the upload process");
+                Debug.Log("[VimeoRecorder] You set autoUpload to false, you can easily use the vimeoPlayer.PublishVideo() to easily trigger the upload process");
             }
         }
             

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -51,7 +51,11 @@ namespace Vimeo.Recorder
             isRecording = false;
             encoder.EndRecording();
 
-            PublishVideo(encoder.GetVideoFilePath());
+            if (autoUpload) {
+                PublishVideo();
+            } else {
+                Debug.Log("[Vimeo] You set autoUpload to false, you can easily use the vimeoPlayer.PublishVideo() to easily trigger the upload process");
+            }
         }
             
         public void CancelRecording()
@@ -62,8 +66,10 @@ namespace Vimeo.Recorder
             Destroy(publisher);
         }
 
-        private void PublishVideo(string filePath)
+        //Used if you want to publish the latest recorded video
+        public void PublishVideo()
         {
+            string filePath = encoder.GetVideoFilePath();
             isUploading = true;
             uploadProgress = 0;
 


### PR DESCRIPTION
- [x] Vimeo Recorder now has a `autoUpload` boolean that controls whether it uploads upon the end of a recording
- [x] Test for recording without uploading