### PR TITLE
A suggested fix to remove ambiguity conflict with a JSON library like…

### DIFF
--- a/Assets/Tests/Play/VimeoRecorderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoRecorderPlayTest.cs
@@ -146,7 +146,7 @@ public class VimeoRecorderPlayTest : TestConfig
 
     private void GetFoldersComplete(string resp)
     {
-        JSONNode json = JSON.Parse(resp);
+        JSONNode json = JSONNode.Parse(resp);
         Assert.AreEqual(recorder.publisher.video.uri, json["data"][0]["uri"].Value);
         finished = true;
     }
@@ -191,7 +191,7 @@ public class VimeoRecorderPlayTest : TestConfig
     private void CheckRecentVideos(string resp)
     {
         Debug.Log("[TEST] CheckRecentVideos " + resp);
-        JSONNode json = JSON.Parse(resp);
+        JSONNode json = JSONNode.Parse(resp);
         
         Assert.AreEqual(json["data"][0]["name"].Value, "Multi Upload Test #2 " + version);
         Assert.AreEqual(json["data"][1]["name"].Value, "Multi Upload Test #1 " + version);

--- a/Assets/Tests/Play/VimeoUploaderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoUploaderPlayTest.cs
@@ -51,7 +51,7 @@ public class VimeoUploaderPlayTest : TestConfig
 
     public void UploadInit(string response)
     {
-        VimeoVideo video = new VimeoVideo(JSON.Parse(response));
+        VimeoVideo video = new VimeoVideo(JSONNode.Parse(response));
         uploader.SetVideoViewPrivacy(VimeoApi.PrivacyModeDisplay.OnlyPeopleWithPrivateLink);
         uploader.SetVideoName("Large file test (" + Application.platform + " " + Application.unityVersion + ")");
         uploader.SaveVideo(video);

--- a/Assets/Tests/Unit/VimeoVideoTest.cs
+++ b/Assets/Tests/Unit/VimeoVideoTest.cs
@@ -19,7 +19,7 @@ public class VimeoVideoTest : TestConfig
     public void _Before()
     {
         
-        video = new VimeoVideo(JSON.Parse(mockDevelopmentJson));
+        video = new VimeoVideo(JSONNode.Parse(mockDevelopmentJson));
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class VimeoVideoTest : TestConfig
     public void GetVideoFileByResolution_Uses_Selected_Resolution_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.NoUnexpectedReceived();
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         JSONNode file = video.GetVideoFileByResolution(Vimeo.Player.StreamingResolution.x720p_HD);
         Assert.AreEqual(file["height"].Value, "720");
     }
@@ -123,14 +123,14 @@ public class VimeoVideoTest : TestConfig
     public void GetHlsUrl_Works_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.NoUnexpectedReceived();
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.getHlsUrl(), "https://player.vimeo.com/external/xxx.m3u8?s=edab7a40157183128871d34b0794feb5f1534501&oauth2_token_id=...");
     }
 
     [Test]
     public void GetDashUrl_Returns_Null_For_Files_Response()
     {
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.getDashUrl(), null);
     }
 
@@ -138,7 +138,7 @@ public class VimeoVideoTest : TestConfig
     public void GetAdaptiveVideoFileURL_Defaults_To_Hls_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.Expect(LogType.Warning, "[Vimeo] No DASH manfiest found. Defaulting to HLS.");
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getHlsUrl());
     }
 #endregion

--- a/Assets/Vimeo/Scripts/Config/PlayerSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/PlayerSettings.cs
@@ -34,7 +34,6 @@ namespace Vimeo.Player
         public Depthkit.Depthkit_Clip depthKitClip;
 #endif         
         public StreamingResolution selectedResolution = StreamingResolution.x2160p_4K; 
-        public string vimeoVideoId;
         public bool muteAudio = false;
         public bool autoPlay = true;
         public int startTime = 0;

--- a/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
@@ -82,6 +82,7 @@ namespace Vimeo.Recorder
 
         public RenderTexture renderTextureTarget;
 
+        public bool replaceExisting = false;
         public VimeoApi.PrivacyModeDisplay privacyMode = VimeoApi.PrivacyModeDisplay.Anyone;
         public VimeoApi.CommentMode commentMode = VimeoApi.CommentMode.Anyone;
         public bool enableDownloads = true;

--- a/Assets/Vimeo/Scripts/Config/VimeoSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/VimeoSettings.cs
@@ -25,6 +25,9 @@ namespace Vimeo
         public bool   signInError = false;
         private const string VIMEO_TOKEN_PREFIX = "vimeo-token-";
 
+        // Played or Overwritten video
+        public string vimeoVideoId;
+
         public int GetCurrentFolderIndex()
         {
             if (currentFolder != null) {

--- a/Assets/Vimeo/Scripts/Config/VimeoVideo.cs
+++ b/Assets/Vimeo/Scripts/Config/VimeoVideo.cs
@@ -137,7 +137,7 @@ namespace Vimeo
             }
 
             try {
-                return JSON.Parse(matches[0].Value);
+                return JSONNode.Parse(matches[0].Value);
             }
             catch (System.Exception e) {
                 Debug.LogError("[Vimeo] There was a problem parsing the JSON. " + e);

--- a/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
@@ -74,7 +74,7 @@ namespace Vimeo
                 DestroyImmediate(settings.gameObject.GetComponent<VimeoApi>());
             }
 
-            var json = JSON.Parse(response);
+            var json = JSONNode.Parse(response);
             JSONNode videoData = json["data"];
 
             if (videoData.Count == 0) {
@@ -118,7 +118,7 @@ namespace Vimeo
                 DestroyImmediate(settings.gameObject.GetComponent<VimeoApi>());
             }
 
-            var json = JSON.Parse(response);
+            var json = JSONNode.Parse(response);
             var folderData = json["data"];
 
             string folder_prefix = "";

--- a/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
@@ -80,7 +80,13 @@ namespace Vimeo.Recorder
                         EditorGUILayout.PropertyField(so.FindProperty("videoPassword"), new GUIContent("Password"));
                     }
 
-                    GUISelectFolder();
+                    EditorGUILayout.PropertyField(so.FindProperty("replaceExisting"));
+
+                    bool updated = GUISelectFolder();
+                    if (IsSelectExisting(recorder))
+                    {
+                        GUISelectVideo(updated);
+                    }
 
                     EditorGUILayout.PropertyField(so.FindProperty("commentMode"), new GUIContent("Comments"));
                     EditorGUILayout.PropertyField(so.FindProperty("enableDownloads"));

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -364,7 +364,7 @@ namespace Vimeo.Player
         {
             loadingVideoMetadata = false;
             
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
             api.OnRequestComplete -= VideoMetadataLoad;
             
             if (json["error"] == null) {

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -52,7 +52,7 @@ namespace Vimeo.Recorder
             m_vimeoUploader.OnRequestComplete -= OnUploadInit;
             m_vimeoUploader.OnRequestComplete += OnVideoUpdated;
 
-            JSONNode jsonResponse = JSON.Parse(response);
+            JSONNode jsonResponse = JSONNode.Parse(response);
             video = new VimeoVideo(jsonResponse);
             
 #if UNITY_2018_1_OR_NEWER
@@ -126,7 +126,7 @@ namespace Vimeo.Recorder
         {
             m_vimeoUploader.OnRequestComplete -= OnVideoUpdated;
 
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
             recorder.videoPermalink = json["link"];
             recorder.videoReviewPermalink = json["review_link"];
 
@@ -144,7 +144,7 @@ namespace Vimeo.Recorder
 
         private void ApiError(string response)
         {
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
 
             if (json["invalid_parameters"] != null) {
                 for (int i = 0; i < json["invalid_parameters"].Count; i++) {

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -93,11 +93,11 @@ namespace Vimeo.Recorder
             return null;
         }
 
-        public void PublishVideo(string filename)
+        public void PublishVideo(string filename, string vimeoId = null)
         {
             if (System.IO.File.Exists(filename)) {
                 Debug.Log("[VimeoRecorder] Uploading to Vimeo");
-                m_vimeoUploader.Upload(filename);
+                m_vimeoUploader.Upload(filename, vimeoId);
             } else {
                 Debug.LogError("File doesn't exist, try recording it again");
             }   

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -85,7 +85,7 @@ namespace Vimeo.Recorder
                 publisher.OnNetworkError += NetworkError;
             }
 
-            publisher.PublishVideo(encoder.GetVideoFilePath());
+            publisher.PublishVideo(encoder.GetVideoFilePath(), replaceExisting ? vimeoVideoId : null);
         }
 
         private void UploadProgress(string status, float progress)

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -175,13 +175,28 @@ namespace Vimeo
             }
         }
 
-        public IEnumerator RequestTusResource(string api_path, long fileByteCount)
+        public IEnumerator TusUploadNew(long fileByteCount)
         {
             string tusResourceRequestBody = "{ \"upload\": { \"approach\": \"tus\", \"size\": \"" + fileByteCount.ToString() + "\" } }";
 
             if (token != null) {
                 using (UnityWebRequest request = UnityWebRequest.Put("https://api.vimeo.com/me/videos", tusResourceRequestBody)) {
                     PrepareTusHeaders(request);
+                    yield return VimeoApi.SendRequest(request);
+                    ResponseHandler(request);
+                }
+            }
+        }
+
+        public IEnumerator TusUploadReplace(string videoId, string file_path, long fileByteCount)
+        {
+            string tusResourceRequestBody = "{ \"file_name\": \"" + file_path + "\", \"upload\": { \"status\": \"in_progress\", \"size\": \"" + fileByteCount.ToString() + "\", \"approach\": \"tus\" } }";
+
+            if (token != null)
+            {
+                using (UnityWebRequest request = UnityWebRequest.Put("https://api.vimeo.com/videos/" + videoId + "/versions", tusResourceRequestBody))
+                {
+                    PrepareTusHeaders(request, false);
                     yield return VimeoApi.SendRequest(request);
                     ResponseHandler(request);
                 }
@@ -239,17 +254,20 @@ namespace Vimeo
             }
         }
 
-        private void PrepareTusHeaders(UnityWebRequest r, string apiVersion = "3.4")
+        private void PrepareTusHeaders(UnityWebRequest r, bool withAuthorization = true, string apiVersion = "3.4")
         {
             r.method = "POST";
             r.SetRequestHeader("Content-Type", "application/json");
-            PrepareHeaders(r, apiVersion);
+            PrepareHeaders(r, withAuthorization, apiVersion);
         }
         
-        private void PrepareHeaders(UnityWebRequest r, string apiVersion = "3.4")
+        private void PrepareHeaders(UnityWebRequest r, bool withAuthorization = true, string apiVersion = "3.4")
         {
             r.chunkedTransfer = false;
-            r.SetRequestHeader("Authorization", "bearer " + token);
+            if (withAuthorization)
+            {
+                r.SetRequestHeader("Authorization", "bearer " + token);
+            }
             r.SetRequestHeader("Accept", "application/vnd.vimeo.*+json;version=" + apiVersion);
         }
 

--- a/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
@@ -90,7 +90,7 @@ namespace Vimeo
         {
             OnRequestComplete -= RequestComplete;
 
-            JSONNode rawJSON = JSON.Parse(response);
+            JSONNode rawJSON = JSONNode.Parse(response);
 
             string tusUploadLink = rawJSON["upload"]["upload_link"].Value;
             m_vimeoUrl = rawJSON["link"].Value;

--- a/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
@@ -105,13 +105,20 @@ namespace Vimeo
             }
         }
 
-        public void Upload(string _file)
+        public void Upload(string _file, string vimeoId = null)
         {
             m_file = _file;
             m_fileInfo = new FileInfo(m_file);
 
             OnRequestComplete += RequestComplete;
-            StartCoroutine(RequestTusResource("me/videos", m_fileInfo.Length));
+            if (vimeoId != null)
+            {
+                StartCoroutine(TusUploadReplace(vimeoId, m_file, m_fileInfo.Length));
+            }
+            else
+            {
+                StartCoroutine(TusUploadNew(m_fileInfo.Length));
+            }
             m_isUploading = true;
         }
 

--- a/Assets/Vimeo/Scripts/Utils/SimpleJSON.cs
+++ b/Assets/Vimeo/Scripts/Utils/SimpleJSON.cs
@@ -1421,14 +1421,4 @@ namespace Vimeo.SimpleJSON
             return "";
         }
     }
-
-    // End of JSONLazyCreator
-
-    public static class JSON
-    {
-        public static JSONNode Parse(string jsonString)
-        {
-            return JSONNode.Parse(jsonString);
-        }
-    }
 }


### PR DESCRIPTION
… Matt Shoen,s: don't use the overloaded JSON symbol, and use a more explicit JSONNode class reference

JSONNode node = JSONNode.Parse(jsonString);
makes more sense than:
JSONNode node = JSON.Parse(jsonString);