### PR TITLE
Fix JSON namespace/class ambiguity

### DIFF
--- a/Assets/Tests/Play/VimeoRecorderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoRecorderPlayTest.cs
@@ -146,7 +146,7 @@ public class VimeoRecorderPlayTest : TestConfig
 
     private void GetFoldersComplete(string resp)
     {
-        JSONNode json = JSON.Parse(resp);
+        JSONNode json = JSONNode.Parse(resp);
         Assert.AreEqual(recorder.publisher.video.uri, json["data"][0]["uri"].Value);
         finished = true;
     }
@@ -191,7 +191,7 @@ public class VimeoRecorderPlayTest : TestConfig
     private void CheckRecentVideos(string resp)
     {
         Debug.Log("[TEST] CheckRecentVideos " + resp);
-        JSONNode json = JSON.Parse(resp);
+        JSONNode json = JSONNode.Parse(resp);
         
         Assert.AreEqual(json["data"][0]["name"].Value, "Multi Upload Test #2 " + version);
         Assert.AreEqual(json["data"][1]["name"].Value, "Multi Upload Test #1 " + version);

--- a/Assets/Tests/Play/VimeoUploaderPlayTest.cs
+++ b/Assets/Tests/Play/VimeoUploaderPlayTest.cs
@@ -51,7 +51,7 @@ public class VimeoUploaderPlayTest : TestConfig
 
     public void UploadInit(string response)
     {
-        VimeoVideo video = new VimeoVideo(JSON.Parse(response));
+        VimeoVideo video = new VimeoVideo(JSONNode.Parse(response));
         uploader.SetVideoViewPrivacy(VimeoApi.PrivacyModeDisplay.OnlyPeopleWithPrivateLink);
         uploader.SetVideoName("Large file test (" + Application.platform + " " + Application.unityVersion + ")");
         uploader.SaveVideo(video);

--- a/Assets/Tests/Unit/VimeoVideoTest.cs
+++ b/Assets/Tests/Unit/VimeoVideoTest.cs
@@ -114,6 +114,7 @@ public class VimeoVideoTest : TestConfig
     
     [Test]
     // TODO somehow test different application platforms
+    // Note: this fails (correctly) when testing on Mac
     public void GetAdaptiveVideoFileURL_Returns_Dash_By_Default()
     {
         Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getDashUrl());
@@ -135,6 +136,8 @@ public class VimeoVideoTest : TestConfig
     }
 
     [Test]
+    // TODO somehow test different application platforms
+    // Note: this fails (correctly) when testing on Mac
     public void GetAdaptiveVideoFileURL_Defaults_To_Hls_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.Expect(LogType.Warning, "[Vimeo] No DASH manfiest found. Defaulting to HLS.");

--- a/Assets/Tests/Unit/VimeoVideoTest.cs
+++ b/Assets/Tests/Unit/VimeoVideoTest.cs
@@ -19,7 +19,7 @@ public class VimeoVideoTest : TestConfig
     public void _Before()
     {
         
-        video = new VimeoVideo(JSON.Parse(mockDevelopmentJson));
+        video = new VimeoVideo(JSONNode.Parse(mockDevelopmentJson));
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class VimeoVideoTest : TestConfig
     public void GetVideoFileByResolution_Uses_Selected_Resolution_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.NoUnexpectedReceived();
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         JSONNode file = video.GetVideoFileByResolution(Vimeo.Player.StreamingResolution.x720p_HD);
         Assert.AreEqual(file["height"].Value, "720");
     }
@@ -123,14 +123,14 @@ public class VimeoVideoTest : TestConfig
     public void GetHlsUrl_Works_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.NoUnexpectedReceived();
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.getHlsUrl(), "https://player.vimeo.com/external/xxx.m3u8?s=edab7a40157183128871d34b0794feb5f1534501&oauth2_token_id=...");
     }
 
     [Test]
     public void GetDashUrl_Returns_Null_For_Files_Response()
     {
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.getDashUrl(), null);
     }
 
@@ -138,7 +138,7 @@ public class VimeoVideoTest : TestConfig
     public void GetAdaptiveVideoFileURL_Defaults_To_Hls_For_Files_Response()
     {
         UnityEngine.TestTools.LogAssert.Expect(LogType.Warning, "[Vimeo] No DASH manfiest found. Defaulting to HLS.");
-        video = new VimeoVideo(JSON.Parse(mockProductionJson));
+        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
         Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getHlsUrl());
     }
 #endregion

--- a/Assets/Vimeo/Scripts/Config/VimeoVideo.cs
+++ b/Assets/Vimeo/Scripts/Config/VimeoVideo.cs
@@ -137,7 +137,7 @@ namespace Vimeo
             }
 
             try {
-                return JSON.Parse(matches[0].Value);
+                return JSONNode.Parse(matches[0].Value);
             }
             catch (System.Exception e) {
                 Debug.LogError("[Vimeo] There was a problem parsing the JSON. " + e);

--- a/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/BaseEditor.cs
@@ -74,7 +74,7 @@ namespace Vimeo
                 DestroyImmediate(settings.gameObject.GetComponent<VimeoApi>());
             }
 
-            var json = JSON.Parse(response);
+            var json = JSONNode.Parse(response);
             JSONNode videoData = json["data"];
 
             if (videoData.Count == 0) {
@@ -118,7 +118,7 @@ namespace Vimeo
                 DestroyImmediate(settings.gameObject.GetComponent<VimeoApi>());
             }
 
-            var json = JSON.Parse(response);
+            var json = JSONNode.Parse(response);
             var folderData = json["data"];
 
             string folder_prefix = "";

--- a/Assets/Vimeo/Scripts/Editor/VimeoPlugin.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoPlugin.cs
@@ -31,7 +31,7 @@ namespace Vimeo
 
     public class VimeoPlugin 
     {
-        public const string Version = "0.9.4";
+        public const string Version = "0.9.5";
         public const string AVPRO_VIDEO_DEFINE      = "VIMEO_AVPRO_VIDEO_SUPPORT";
         public const string AVPRO_CAPTURE_DEFINE    = "VIMEO_AVPRO_CAPTURE_SUPPORT";
         public const string DEPTHKIT_DEFINE         = "VIMEO_DEPTHKIT_SUPPORT";

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -364,7 +364,7 @@ namespace Vimeo.Player
         {
             loadingVideoMetadata = false;
             
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
             api.OnRequestComplete -= VideoMetadataLoad;
             
             if (json["error"] == null) {

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -52,7 +52,7 @@ namespace Vimeo.Recorder
             m_vimeoUploader.OnRequestComplete -= OnUploadInit;
             m_vimeoUploader.OnRequestComplete += OnVideoUpdated;
 
-            JSONNode jsonResponse = JSON.Parse(response);
+            JSONNode jsonResponse = JSONNode.Parse(response);
             video = new VimeoVideo(jsonResponse);
             
 #if UNITY_2018_1_OR_NEWER
@@ -126,7 +126,7 @@ namespace Vimeo.Recorder
         {
             m_vimeoUploader.OnRequestComplete -= OnVideoUpdated;
 
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
             recorder.videoPermalink = json["link"];
             recorder.videoReviewPermalink = json["review_link"];
 
@@ -144,7 +144,7 @@ namespace Vimeo.Recorder
 
         private void ApiError(string response)
         {
-            JSONNode json = JSON.Parse(response);
+            JSONNode json = JSONNode.Parse(response);
 
             if (json["invalid_parameters"] != null) {
                 for (int i = 0; i < json["invalid_parameters"].Count; i++) {

--- a/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
@@ -90,7 +90,7 @@ namespace Vimeo
         {
             OnRequestComplete -= RequestComplete;
 
-            JSONNode rawJSON = JSON.Parse(response);
+            JSONNode rawJSON = JSONNode.Parse(response);
 
             string tusUploadLink = rawJSON["upload"]["upload_link"].Value;
             m_vimeoUrl = rawJSON["link"].Value;

--- a/Assets/Vimeo/Scripts/Utils/SimpleJSON.cs
+++ b/Assets/Vimeo/Scripts/Utils/SimpleJSON.cs
@@ -1421,14 +1421,4 @@ namespace Vimeo.SimpleJSON
             return "";
         }
     }
-
-    // End of JSONLazyCreator
-
-    public static class JSON
-    {
-        public static JSONNode Parse(string jsonString)
-        {
-            return JSONNode.Parse(jsonString);
-        }
-    }
 }


### PR DESCRIPTION
A suggested fix for issue #51 , to remove ambiguity conflict with a JSON library like Matt Shoen's: don't use the overloaded JSON symbol, and instead use directly the JSONNode class:

JSONNode node = JSONNode.Parse(jsonString);
feels better than:
JSONNode node = JSON.Parse(jsonString);
