### PR TITLE
Add support for replacing Vimeo video (Issue #55)

### DIFF
--- a/Assets/Vimeo/Scripts/Config/PlayerSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/PlayerSettings.cs
@@ -34,7 +34,6 @@ namespace Vimeo.Player
         public Depthkit.Depthkit_Clip depthKitClip;
 #endif         
         public StreamingResolution selectedResolution = StreamingResolution.x2160p_4K; 
-        public string vimeoVideoId;
         public bool muteAudio = false;
         public bool autoPlay = true;
         public int startTime = 0;

--- a/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/RecorderSettings.cs
@@ -82,6 +82,7 @@ namespace Vimeo.Recorder
 
         public RenderTexture renderTextureTarget;
 
+        public bool replaceExisting = false;
         public VimeoApi.PrivacyModeDisplay privacyMode = VimeoApi.PrivacyModeDisplay.Anyone;
         public VimeoApi.CommentMode commentMode = VimeoApi.CommentMode.Anyone;
         public bool enableDownloads = true;

--- a/Assets/Vimeo/Scripts/Config/VimeoSettings.cs
+++ b/Assets/Vimeo/Scripts/Config/VimeoSettings.cs
@@ -25,6 +25,9 @@ namespace Vimeo
         public bool   signInError = false;
         private const string VIMEO_TOKEN_PREFIX = "vimeo-token-";
 
+        // Played or Overwritten video
+        public string vimeoVideoId;
+
         public int GetCurrentFolderIndex()
         {
             if (currentFolder != null) {

--- a/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoRecorderEditor.cs
@@ -80,7 +80,13 @@ namespace Vimeo.Recorder
                         EditorGUILayout.PropertyField(so.FindProperty("videoPassword"), new GUIContent("Password"));
                     }
 
-                    GUISelectFolder();
+                    EditorGUILayout.PropertyField(so.FindProperty("replaceExisting"));
+
+                    bool updated = GUISelectFolder();
+                    if (IsSelectExisting(recorder))
+                    {
+                        GUISelectVideo(updated);
+                    }
 
                     EditorGUILayout.PropertyField(so.FindProperty("commentMode"), new GUIContent("Comments"));
                     EditorGUILayout.PropertyField(so.FindProperty("enableDownloads"));

--- a/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoPublisher.cs
@@ -93,11 +93,11 @@ namespace Vimeo.Recorder
             return null;
         }
 
-        public void PublishVideo(string filename)
+        public void PublishVideo(string filename, string vimeoId = null)
         {
             if (System.IO.File.Exists(filename)) {
                 Debug.Log("[VimeoRecorder] Uploading to Vimeo");
-                m_vimeoUploader.Upload(filename);
+                m_vimeoUploader.Upload(filename, vimeoId);
             } else {
                 Debug.LogError("File doesn't exist, try recording it again");
             }   

--- a/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
+++ b/Assets/Vimeo/Scripts/Recorder/VimeoRecorder.cs
@@ -85,7 +85,7 @@ namespace Vimeo.Recorder
                 publisher.OnNetworkError += NetworkError;
             }
 
-            publisher.PublishVideo(encoder.GetVideoFilePath());
+            publisher.PublishVideo(encoder.GetVideoFilePath(), replaceExisting ? vimeoVideoId : null);
         }
 
         private void UploadProgress(string status, float progress)

--- a/Assets/Vimeo/Scripts/Services/VimeoApi.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoApi.cs
@@ -175,13 +175,28 @@ namespace Vimeo
             }
         }
 
-        public IEnumerator RequestTusResource(string api_path, long fileByteCount)
+        public IEnumerator TusUploadNew(long fileByteCount)
         {
             string tusResourceRequestBody = "{ \"upload\": { \"approach\": \"tus\", \"size\": \"" + fileByteCount.ToString() + "\" } }";
 
             if (token != null) {
                 using (UnityWebRequest request = UnityWebRequest.Put("https://api.vimeo.com/me/videos", tusResourceRequestBody)) {
                     PrepareTusHeaders(request);
+                    yield return VimeoApi.SendRequest(request);
+                    ResponseHandler(request);
+                }
+            }
+        }
+
+        public IEnumerator TusUploadReplace(string videoId, string file_path, long fileByteCount)
+        {
+            string tusResourceRequestBody = "{ \"file_name\": \"" + file_path + "\", \"upload\": { \"status\": \"in_progress\", \"size\": \"" + fileByteCount.ToString() + "\", \"approach\": \"tus\" } }";
+
+            if (token != null)
+            {
+                using (UnityWebRequest request = UnityWebRequest.Put("https://api.vimeo.com/videos/" + videoId + "/versions", tusResourceRequestBody))
+                {
+                    PrepareTusHeaders(request, false);
                     yield return VimeoApi.SendRequest(request);
                     ResponseHandler(request);
                 }
@@ -239,17 +254,20 @@ namespace Vimeo
             }
         }
 
-        private void PrepareTusHeaders(UnityWebRequest r, string apiVersion = "3.4")
+        private void PrepareTusHeaders(UnityWebRequest r, bool withAuthorization = true, string apiVersion = "3.4")
         {
             r.method = "POST";
             r.SetRequestHeader("Content-Type", "application/json");
-            PrepareHeaders(r, apiVersion);
+            PrepareHeaders(r, withAuthorization, apiVersion);
         }
         
-        private void PrepareHeaders(UnityWebRequest r, string apiVersion = "3.4")
+        private void PrepareHeaders(UnityWebRequest r, bool withAuthorization = true, string apiVersion = "3.4")
         {
             r.chunkedTransfer = false;
-            r.SetRequestHeader("Authorization", "bearer " + token);
+            if (withAuthorization)
+            {
+                r.SetRequestHeader("Authorization", "bearer " + token);
+            }
             r.SetRequestHeader("Accept", "application/vnd.vimeo.*+json;version=" + apiVersion);
         }
 

--- a/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
+++ b/Assets/Vimeo/Scripts/Services/VimeoUploader.cs
@@ -105,13 +105,20 @@ namespace Vimeo
             }
         }
 
-        public void Upload(string _file)
+        public void Upload(string _file, string vimeoId = null)
         {
             m_file = _file;
             m_fileInfo = new FileInfo(m_file);
 
             OnRequestComplete += RequestComplete;
-            StartCoroutine(RequestTusResource("me/videos", m_fileInfo.Length));
+            if (vimeoId != null)
+            {
+                StartCoroutine(TusUploadReplace(vimeoId, m_file, m_fileInfo.Length));
+            }
+            else
+            {
+                StartCoroutine(TusUploadNew(m_fileInfo.Length));
+            }
             m_isUploading = true;
         }
 


### PR DESCRIPTION
WIP: Partial fix for Issue #55 

Add support for replacing existing video. But I get an error message from the Vimeo server

- Added to VimeoRecorder Editor GUI
- Added a replaceExisting boolean field to VimeoRecorder

Went according to documentation in:
https://developer.vimeo.com/api/upload/videos#replacing-a-source-file

But I get this error:
[VimeoApi] 401 Unauthorized request. Are you using a valid token?

Actually it makes sense, as it is quite weird that the documentation doesn't specify to add the authorization token in the header.

So, I added it, but then I still get another error:

[VimeoApi] https://api.vimeo.com/videos/307965347/versions - {"error":"Something strange occurred. Please try again.","link":null,"developer_message":"The body of this HTTP request is not formatted properly. Please check the content-type header and raw body.","error_code":2205}

