### PR TITLE
Unfurl adaptive video file links

### DIFF
--- a/Assets/Tests/Play/VimeoPlayerPlayTest.cs
+++ b/Assets/Tests/Play/VimeoPlayerPlayTest.cs
@@ -121,6 +121,21 @@ public class VimeoPlayerPlayTest : TestConfig
         Assert.IsEmpty(player.controller.videoPlayer.url);
     }
 
+    [UnityTest]
+    public IEnumerator Unfurl_Makes_A_Request_And_Redirects_Sucssesfully()
+    {
+        yield return player.Unfurl(TestConfig.TEST_ADAPTIVE_LINK_TO_UNFURL);
+        Assert.AreNotEqual(player.m_file_url, TestConfig.TEST_ADAPTIVE_LINK_TO_UNFURL);
+    }
+
+    [UnityTest]
+    public IEnumerator Unfurl_Does_Not_Redirect_If_Provided_A_Link_That_Does_Not_Redirect()
+    {
+        yield return player.Unfurl(TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
+        Debug.Log(TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
+        Assert.AreEqual(player.m_file_url, TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
+    }
+
     private void EventTriggered()
     {
         triggered = true;

--- a/Assets/Tests/Play/VimeoPlayerPlayTest.cs
+++ b/Assets/Tests/Play/VimeoPlayerPlayTest.cs
@@ -122,17 +122,39 @@ public class VimeoPlayerPlayTest : TestConfig
     }
 
     [UnityTest]
-    public IEnumerator Unfurl_Makes_A_Request_And_Redirects_Sucssesfully()
+    public IEnumerator Unfurl_Makes_A_Request_To_Vimeo_And_Redirects_Sucssesfully()
     {
-        yield return player.Unfurl(TestConfig.TEST_ADAPTIVE_LINK_TO_UNFURL);
-        Assert.AreNotEqual(player.m_file_url, TestConfig.TEST_ADAPTIVE_LINK_TO_UNFURL);
+        player.OnVideoMetadataLoad += EventTriggered;
+
+        player.SignIn(VALID_STREAMING_TOKEN);
+        player.LoadVideo(VALID_VIMEO_VIDEO_ID);
+
+        yield return new WaitUntil(()=> triggered);
+
+        string linkToUnfurl = player.vimeoVideo.GetAdaptiveVideoFileURL();
+        yield return player.Unfurl(linkToUnfurl);
+
+        Assert.AreNotEqual(player.m_file_url, linkToUnfurl);
     }
 
     [UnityTest]
     public IEnumerator Unfurl_Does_Not_Redirect_If_Provided_A_Link_That_Does_Not_Redirect()
     {
-        yield return player.Unfurl(TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
-        Assert.AreEqual(player.m_file_url, TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
+        player.OnVideoMetadataLoad += EventTriggered;
+
+        player.SignIn(VALID_STREAMING_TOKEN);
+        player.LoadVideo(VALID_VIMEO_VIDEO_ID);
+
+        yield return new WaitUntil(()=> triggered);
+
+        string linkToUnfurl = player.vimeoVideo.GetAdaptiveVideoFileURL();
+        yield return player.Unfurl(linkToUnfurl);
+
+        string unfurledLink = player.m_file_url;
+
+        yield return player.Unfurl(unfurledLink);
+
+        Assert.AreEqual(player.m_file_url, unfurledLink);
     }
 
     private void EventTriggered()

--- a/Assets/Tests/Play/VimeoPlayerPlayTest.cs
+++ b/Assets/Tests/Play/VimeoPlayerPlayTest.cs
@@ -132,7 +132,6 @@ public class VimeoPlayerPlayTest : TestConfig
     public IEnumerator Unfurl_Does_Not_Redirect_If_Provided_A_Link_That_Does_Not_Redirect()
     {
         yield return player.Unfurl(TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
-        Debug.Log(TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
         Assert.AreEqual(player.m_file_url, TestConfig.TEST_ADAPTIVE_MANIFEST_URL);
     }
 

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -207,7 +207,7 @@ namespace Vimeo.Player
             }
         }
 
-        private IEnumerator VideoControllerPlayVideo()
+        public IEnumerator VideoControllerPlayVideo()
         {
             videoControllerReady = true;
 
@@ -264,6 +264,7 @@ namespace Vimeo.Player
                 }
 #endif // VIMEO_DEPTHKIT_SUPPORT
             }
+            yield break;
         }
 
         public void Pause()

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -41,7 +41,7 @@ namespace Vimeo.Player
         private bool playVideoAfterLoad = false;
         private bool videoControllerReady = false;
 
-        private string file_url;
+        public string m_file_url;
 
         public void Start()
         {
@@ -220,18 +220,18 @@ namespace Vimeo.Player
                     yield return Unfurl(vimeoVideo.GetAdaptiveVideoFileURL());
                 }
                 else {
-                    file_url = vimeoVideo.GetVideoFileUrlByResolution(selectedResolution);
+                    m_file_url = vimeoVideo.GetVideoFileUrlByResolution(selectedResolution);
                 }
                 
                 if (videoPlayerType == VideoPlayerType.AVProVideo && mediaPlayer != null) {
-                    mediaPlayer.OpenVideoFromFile(RenderHeads.Media.AVProVideo.MediaPlayer.FileLocation.AbsolutePathOrURL, file_url, autoPlay || playVideoAfterLoad);
+                    mediaPlayer.OpenVideoFromFile(RenderHeads.Media.AVProVideo.MediaPlayer.FileLocation.AbsolutePathOrURL, m_file_url, autoPlay || playVideoAfterLoad);
                 } 
 #endif // VIMEO_AVPRO_VIDEO_SUPPORT
 #if VIMEO_DEPTHKIT_SUPPORT
                 if (videoPlayerType == VideoPlayerType.Depthkit && depthKitClip != null) {
 #if VIMEO_AVPRO_VIDEO_SUPPORT   
                     if (depthKitClip.gameObject.GetComponent<RenderHeads.Media.AVProVideo.MediaPlayer>() != null){
-                        depthKitClip.gameObject.GetComponent<RenderHeads.Media.AVProVideo.MediaPlayer>().OpenVideoFromFile(RenderHeads.Media.AVProVideo.MediaPlayer.FileLocation.AbsolutePathOrURL, file_url, autoPlay);
+                        depthKitClip.gameObject.GetComponent<RenderHeads.Media.AVProVideo.MediaPlayer>().OpenVideoFromFile(RenderHeads.Media.AVProVideo.MediaPlayer.FileLocation.AbsolutePathOrURL, m_file_url, autoPlay);
                     }
 #endif // VIMEO_AVPRO_VIDEO_SUPPORT
                     if (depthKitClip.gameObject.GetComponent<VideoPlayer>() != null) {
@@ -394,7 +394,7 @@ namespace Vimeo.Player
             }
         }
 
-        private IEnumerator Unfurl(string url)
+        public IEnumerator Unfurl(string url)
         {
             using (UnityWebRequest www = UnityWebRequest.Get(url)) {
 #if UNITY_2017_2_OR_NEWER
@@ -404,15 +404,15 @@ namespace Vimeo.Player
 #endif
 
 #if UNITY_2017_1_OR_NEWER
-                if (!www.isNetworkError)
+                if (!www.isNetworkError && www.url != url)
 #else
-                if (!www.isError)
+                if (!www.isError && www.url != url)
 #endif
                 {
-                    file_url = www.url;
+                    m_file_url = www.url;
                 } 
                 else {
-                    file_url = url;
+                    m_file_url = url;
                 }
             }
         }

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -399,8 +399,9 @@ namespace Vimeo.Player
         {
             using (UnityWebRequest www = UnityWebRequest.Get(url)) {
                 yield return VimeoApi.SendRequest(www);
+                
 
-                if (VimeoApi.IsNetworkError(www))
+                if (!VimeoApi.IsNetworkError(www))
                 {
                     m_file_url = www.url;
                 } 

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -398,17 +398,9 @@ namespace Vimeo.Player
         public IEnumerator Unfurl(string url)
         {
             using (UnityWebRequest www = UnityWebRequest.Get(url)) {
-#if UNITY_2017_2_OR_NEWER
-                yield return www.SendWebRequest();
-#else
-                yield return www.Send();
-#endif
+                yield return VimeoApi.SendRequest(www);
 
-#if UNITY_2017_1_OR_NEWER
-                if (!www.isNetworkError && www.url != url)
-#else
-                if (!www.isError && www.url != url)
-#endif
+                if (VimeoApi.IsNetworkError(www))
                 {
                     m_file_url = www.url;
                 } 

--- a/Assets/Vimeo/Scripts/TestConfigSample.cs
+++ b/Assets/Vimeo/Scripts/TestConfigSample.cs
@@ -17,7 +17,4 @@ public class TestConfigSample
     public const string TEST_PROJECT_FOLDER = "/users/xxx/projects/xxx";
     public const string VERY_BIG_FILE_PATH = "path/to/very/big/file.mp4";
     public const string TEST_IMAGE_PATH = "D:/dev/vimeo-unity-sdk/Assets/Vimeo/Images/vimeo_v_blue.png";
-    public const string TEST_ADAPTIVE_LINK_TO_UNFURL = "some_link_from_the_vimeo_api_to_an_adaptive_video";
-    public const string TEST_ADAPTIVE_MANIFEST_URL = "some_link_from_the_vimeo_api_to_an_adaptive_manifest_file";
-    
 }

--- a/Assets/Vimeo/Scripts/TestConfigSample.cs
+++ b/Assets/Vimeo/Scripts/TestConfigSample.cs
@@ -17,5 +17,7 @@ public class TestConfigSample
     public const string TEST_PROJECT_FOLDER = "/users/xxx/projects/xxx";
     public const string VERY_BIG_FILE_PATH = "path/to/very/big/file.mp4";
     public const string TEST_IMAGE_PATH = "D:/dev/vimeo-unity-sdk/Assets/Vimeo/Images/vimeo_v_blue.png";
+    public const string TEST_ADAPTIVE_LINK_TO_UNFURL = "some_link_from_the_vimeo_api_to_an_adaptive_video";
+    public const string TEST_ADAPTIVE_MANIFEST_URL = "some_link_from_the_vimeo_api_to_an_adaptive_manifest_file";
     
 }


### PR DESCRIPTION
**What?**
- Adding an `Unfurl` coroutine to the Vimeo Player so that when it get's adaptive streams from the API it unfurls them to the right manifest destination. Fixes #56
- Adding basic tests to check that `Unfurl` is unfurling when it should/should not

Tested against:
- Unity 2018.2.18f1
- Unity 2017.4.16f1