### PR TITLE
Adding an audio listener to the VimeoPlayer integration tests scene

### DIFF
--- a/Assets/Tests/Play/VimeoPlayerPlayTest.cs
+++ b/Assets/Tests/Play/VimeoPlayerPlayTest.cs
@@ -24,6 +24,7 @@ public class VimeoPlayerPlayTest : TestConfig
         camObj = new GameObject();
         camObj.AddComponent<Camera>();
         camObj.transform.Translate(0, 0, 3);
+        camObj.AddComponent<AudioListener>();
 
         // Player Setup
         playerObj = new GameObject();


### PR DESCRIPTION
Solves #79 by adding an `AudioListener` to the scene

Tested against:
- 2018.2.1.18f1
- 2017.4.16f1
- 5.6.4f1