### PR TITLE
Unity 2019 Fixes

### DIFF
--- a/Assets/Tests/Unit/VimeoVideoTest.cs
+++ b/Assets/Tests/Unit/VimeoVideoTest.cs
@@ -113,11 +113,13 @@ public class VimeoVideoTest : TestConfig
     }
 
     [Test]
-    // TODO somehow test different application platforms
-    // Note: this fails (correctly) when testing on Mac
-    public void GetAdaptiveVideoFileURL_Returns_Dash_By_Default()
+    public void GetAdaptiveVideoFileURL_Returns_Correct_Adaptive_Manifest_Based_On_Platform()
     {
-        Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getDashUrl());
+        if (isApple()) {
+            Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getHlsUrl());
+        } else {
+            Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getDashUrl());
+        }
     }
 
     [Test]
@@ -135,20 +137,19 @@ public class VimeoVideoTest : TestConfig
         Assert.AreEqual(video.getDashUrl(), null);
     }
 
-    [Test]
-    // TODO somehow test different application platforms
-    // Note: this fails (correctly) when testing on Mac
-    public void GetAdaptiveVideoFileURL_Defaults_To_Hls_For_Files_Response()
-    {
-        UnityEngine.TestTools.LogAssert.Expect(LogType.Warning, "[Vimeo] No DASH manfiest found. Defaulting to HLS.");
-        video = new VimeoVideo(JSONNode.Parse(mockProductionJson));
-        Assert.AreEqual(video.GetAdaptiveVideoFileURL(), video.getHlsUrl());
-    }
     #endregion
 
     [TearDown]
     public void _After()
     {
 
+    }
+
+    public bool isApple()
+    {
+        return Application.platform == RuntimePlatform.OSXPlayer ||
+                Application.platform == RuntimePlatform.OSXEditor ||
+                Application.platform == RuntimePlatform.IPhonePlayer ||
+                Application.platform == RuntimePlatform.tvOS;
     }
 }

--- a/Assets/Vimeo/Scenes/CanvasPlayer.unity
+++ b/Assets/Vimeo/Scenes/CanvasPlayer.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,7 +38,8 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3731316, g: 0.38074902, b: 0.3587254, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074, b: 0.35872698, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -49,20 +50,19 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -89,6 +95,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -114,142 +121,2288 @@ NavMeshSettings:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1001 &240301501
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224921726650614060, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.145
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224921726650614060, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.145
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.145
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 2}
+        type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.size
+      value: 101
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: uid
+      value: 6b82e032-b17f-4cab-a22c-fa15545b9ce5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoToken
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoSignIn
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[0].name
+      value: '---- Find a video ----'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentFolder.name
+      value: Most recent videos
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[1].name
+      value: Get video by ID or URL
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[1].uri
+      value: custom
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[2].name
+      value: Most recent videos
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[2].uri
+      value: recent
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[3].name
+      value: Projects / Inside Vimeo
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[3].uri
+      value: /users/10945988/projects/438887
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[3].id
+      value: 438887
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[4].name
+      value: Projects / Looking Glass
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[4].uri
+      value: /users/10945988/projects/510800
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[4].id
+      value: 510800
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[5].name
+      value: Projects / Unity Tests
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[5].uri
+      value: /users/10945988/projects/640966
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoFolders.Array.data[5].id
+      value: 640966
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[0].name
+      value: '---- Select a video ----'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[0].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentFolder.uri
+      value: recent
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentVideo.name
+      value: Glitch (329210455)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentVideo.uri
+      value: /videos/329210455
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentVideo.id
+      value: 329210455
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: currentVideo.stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[1].name
+      value: Vimeo OFFF Projection Mapping (331447933)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[1].uri
+      value: /videos/331447933
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[1].id
+      value: 331447933
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[1].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[2].name
+      value: Bubbles (331319640)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[2].uri
+      value: /videos/331319640
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[2].id
+      value: 331319640
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[2].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[3].name
+      value: Vimeo_OFFF_Rooms_v2 (331251315)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[3].uri
+      value: /videos/331251315
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[3].id
+      value: 331251315
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[3].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[4].name
+      value: Vimeo_OFFF_Bubbles_v2 (331250140)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[4].uri
+      value: /videos/331250140
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[4].id
+      value: 331250140
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[4].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[5].name
+      value: Vimeo_OFFF_Glitch_v2 (331247618)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[5].uri
+      value: /videos/331247618
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[5].id
+      value: 331247618
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[5].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[6].name
+      value: Vimeo_OFFF_Ariel_v2 (331246689)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[6].uri
+      value: /videos/331246689
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[6].id
+      value: 331246689
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[6].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[7].name
+      value: Synth.io WIP Walkthrough (330682435)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[7].uri
+      value: /videos/330682435
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[7].id
+      value: 330682435
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[7].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[8].name
+      value: 360 (329630274)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[8].uri
+      value: /videos/329630274
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[8].id
+      value: 329630274
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[8].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[9].name
+      value: Vimeo - OFFF Projection Mapping Test (329214614)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[9].uri
+      value: /videos/329214614
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[9].id
+      value: 329214614
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[9].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[10].name
+      value: Rooms (329210480)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[10].uri
+      value: /videos/329210480
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[10].id
+      value: 329210480
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[10].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[11].name
+      value: Glitch (329210455)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[11].uri
+      value: /videos/329210455
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[11].id
+      value: 329210455
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[11].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[12].name
+      value: Bubbles (329210391)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[12].uri
+      value: /videos/329210391
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[12].id
+      value: 329210391
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[12].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[13].name
+      value: Ariel (329210310)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[13].uri
+      value: /videos/329210310
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[13].id
+      value: 329210310
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[13].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[14].name
+      value: 'Vimeo OFFF New Fabrication Mockup #1 (328747593)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[14].uri
+      value: /videos/328747593
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[14].id
+      value: 328747593
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[14].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[15].name
+      value: test (328572534)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[15].uri
+      value: /videos/328572534
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[15].id
+      value: 328572534
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[15].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[16].name
+      value: Vimeo OFFF test (328257415)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[16].uri
+      value: /videos/328257415
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[16].id
+      value: 328257415
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[16].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[17].name
+      value: Low poly logo (327781516)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[17].uri
+      value: /videos/327781516
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[17].id
+      value: 327781516
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[17].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[18].name
+      value: LKG Vimeo (326681809)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[18].uri
+      value: /videos/326681809
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[18].id
+      value: 326681809
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[18].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[19].name
+      value: Large file test (OSXEditor 2017.1.4f1) (326420860)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[19].uri
+      value: /videos/326420860
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[19].id
+      value: 326420860
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[19].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[20].name
+      value: Large file test (OSXEditor 2018.3.6f1) (326418690)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[20].uri
+      value: /videos/326418690
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[20].id
+      value: 326418690
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[20].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[21].name
+      value: Folder Test (OSXEditor 2018.3.6f1) (326418591)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[21].uri
+      value: /videos/326418591
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[21].id
+      value: 326418591
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[21].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[22].name
+      value: 'Multi Upload Test #2 (OSXEditor 2018.3.6f1) (326418559)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[22].uri
+      value: /videos/326418559
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[22].id
+      value: 326418559
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[22].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[23].name
+      value: 'Multi Upload Test #1 (OSXEditor 2018.3.6f1) (326418535)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[23].uri
+      value: /videos/326418535
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[23].id
+      value: 326418535
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[23].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[24].name
+      value: Screen Test (OSXEditor 2018.3.6f1) (326418508)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[24].uri
+      value: /videos/326418508
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[24].id
+      value: 326418508
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[24].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[25].name
+      value: MainCamera Test (OSXEditor 2018.3.6f1) (326418468)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[25].uri
+      value: /videos/326418468
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[25].id
+      value: 326418468
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[25].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[26].name
+      value: Multi Chunk Test (OSXEditor 2018.3.6f1) (326418417)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[26].uri
+      value: /videos/326418417
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[26].id
+      value: 326418417
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[26].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[27].name
+      value: Folder Test (OSXEditor 2018.2.14f1) (326417432)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[27].uri
+      value: /videos/326417432
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[27].id
+      value: 326417432
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[27].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[28].name
+      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (326417391)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[28].uri
+      value: /videos/326417391
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[28].id
+      value: 326417391
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[28].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[29].name
+      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326417357)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[29].uri
+      value: /videos/326417357
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[29].id
+      value: 326417357
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[29].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[30].name
+      value: Screen Test (OSXEditor 2018.2.14f1) (326417326)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[30].uri
+      value: /videos/326417326
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[30].id
+      value: 326417326
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[30].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[31].name
+      value: MainCamera Test (OSXEditor 2018.2.14f1) (326417300)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[31].uri
+      value: /videos/326417300
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[31].id
+      value: 326417300
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[31].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[32].name
+      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (326417243)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[32].uri
+      value: /videos/326417243
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[32].id
+      value: 326417243
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[32].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[33].name
+      value: Large file test (OSXEditor 2018.2.14f1) (326417155)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[33].uri
+      value: /videos/326417155
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[33].id
+      value: 326417155
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[33].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[34].name
+      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326416974)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[34].uri
+      value: /videos/326416974
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[34].id
+      value: 326416974
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[34].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[35].name
+      value: MainCamera Test (OSXEditor 2018.2.14f1) (326416679)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[35].uri
+      value: /videos/326416679
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[35].id
+      value: 326416679
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[35].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[36].name
+      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (326416644)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[36].uri
+      value: /videos/326416644
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[36].id
+      value: 326416644
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[36].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[37].name
+      value: Folder Test (OSXEditor 2018.2.14f1) (325672606)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[37].uri
+      value: /videos/325672606
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[37].id
+      value: 325672606
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[37].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[38].name
+      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (325672569)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[38].uri
+      value: /videos/325672569
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[38].id
+      value: 325672569
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[38].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[39].name
+      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (325672545)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[39].uri
+      value: /videos/325672545
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[39].id
+      value: 325672545
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[39].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[40].name
+      value: Screen Test (OSXEditor 2018.2.14f1) (325672506)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[40].uri
+      value: /videos/325672506
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[40].id
+      value: 325672506
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[40].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[41].name
+      value: MainCamera Test (OSXEditor 2018.2.14f1) (325672467)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[41].uri
+      value: /videos/325672467
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[41].id
+      value: 325672467
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[41].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[42].name
+      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (325672405)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[42].uri
+      value: /videos/325672405
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[42].id
+      value: 325672405
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[42].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[43].name
+      value: Birthday (324001683)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[43].uri
+      value: /videos/324001683
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[43].id
+      value: 324001683
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[43].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[44].name
+      value: Bi (324001682)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[44].uri
+      value: /videos/324001682
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[44].id
+      value: 324001682
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[44].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[45].name
+      value: test4 (324001681)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[45].uri
+      value: /videos/324001681
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[45].id
+      value: 324001681
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[45].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[46].name
+      value: Cake (324001405)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[46].uri
+      value: /videos/324001405
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[46].id
+      value: 324001405
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[46].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[47].name
+      value: Untitled (323997910)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[47].uri
+      value: /videos/323997910
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[47].id
+      value: 323997910
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[47].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[48].name
+      value: Race (323997909)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[48].uri
+      value: /videos/323997909
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[48].id
+      value: 323997909
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[48].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[49].name
+      value: race (323997908)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[49].uri
+      value: /videos/323997908
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[49].id
+      value: 323997908
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[49].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[50].name
+      value: Travel (323997660)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[50].uri
+      value: /videos/323997660
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[50].id
+      value: 323997660
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[50].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[51].name
+      value: Hip (323997309)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[51].uri
+      value: /videos/323997309
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[51].id
+      value: 323997309
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[51].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[52].name
+      value: travel (323997192)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[52].uri
+      value: /videos/323997192
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[52].id
+      value: 323997192
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[52].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[53].name
+      value: Auto generated marketing video - Bike Shop (v1) (323794820)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[53].uri
+      value: /videos/323794820
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[53].id
+      value: 323794820
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[53].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[54].name
+      value: itp   U+1F354 (322063174)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[54].uri
+      value: /videos/322063174
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[54].id
+      value: 322063174
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[54].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[55].name
+      value: TestEventThinko (321767823)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[55].uri
+      value: /videos/321767823
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[55].id
+      value: 321767823
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[55].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[56].name
+      value: Folder Test (OSXEditor 2018.2.14f1) (321529342)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[56].uri
+      value: /videos/321529342
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[56].id
+      value: 321529342
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[56].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[57].name
+      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (321529316)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[57].uri
+      value: /videos/321529316
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[57].id
+      value: 321529316
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[57].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[58].name
+      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (321529291)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[58].uri
+      value: /videos/321529291
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[58].id
+      value: 321529291
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[58].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[59].name
+      value: Screen Test (OSXEditor 2018.2.14f1) (321529263)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[59].uri
+      value: /videos/321529263
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[59].id
+      value: 321529263
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[59].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[60].name
+      value: MainCamera Test (OSXEditor 2018.2.14f1) (321529226)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[60].uri
+      value: /videos/321529226
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[60].id
+      value: 321529226
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[60].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[61].name
+      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (321529178)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[61].uri
+      value: /videos/321529178
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[61].id
+      value: 321529178
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[61].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[62].name
+      value: New Unity Recorder Test (321517785)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[62].uri
+      value: /videos/321517785
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[62].id
+      value: 321517785
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[62].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[63].name
+      value: testStreamFromAPI (320531441)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[63].uri
+      value: /videos/320531441
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[63].id
+      value: 320531441
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[63].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[64].name
+      value: testStreamFromAPI (320527769)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[64].uri
+      value: /videos/320527769
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[64].id
+      value: 320527769
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[64].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[65].name
+      value: testEvent (320526358)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[65].uri
+      value: /videos/320526358
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[65].id
+      value: 320526358
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[65].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[66].name
+      value: testEvent (320517114)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[66].uri
+      value: /videos/320517114
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[66].id
+      value: 320517114
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[66].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[67].name
+      value: Creating Live event from an API request (320370706)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[67].uri
+      value: /videos/320370706
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[67].id
+      value: 320370706
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[67].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[68].name
+      value: Second test with Kenya (320364272)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[68].uri
+      value: /videos/320364272
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[68].id
+      value: 320364272
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[68].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[69].name
+      value: Testing with Kenya creating a live event (320363254)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[69].uri
+      value: /videos/320363254
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[69].id
+      value: 320363254
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[69].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[70].name
+      value: Untitled (320297769)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[70].uri
+      value: /videos/320297769
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[70].id
+      value: 320297769
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[70].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[71].name
+      value: Untitled (320297659)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[71].uri
+      value: /videos/320297659
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[71].id
+      value: 320297659
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[71].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[72].name
+      value: UnityLiveStreamTest - Long Shot Camera (320292249)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[72].uri
+      value: /videos/320292249
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[72].id
+      value: 320292249
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[72].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[73].name
+      value: UnityLiveStreamTest - Side Shot Camera (320292011)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[73].uri
+      value: /videos/320292011
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[73].id
+      value: 320292011
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[73].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[74].name
+      value: UnityLiveStreamTest - Close Up Camera (320291760)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[74].uri
+      value: /videos/320291760
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[74].id
+      value: 320291760
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[74].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[75].name
+      value: WindowsUnityLivestreamTest (320266469)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[75].uri
+      value: /videos/320266469
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[75].id
+      value: 320266469
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[75].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[76].name
+      value: Live Streaming from a Unity camera to the iOS Vimeo app (320041059)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[76].uri
+      value: /videos/320041059
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[76].id
+      value: 320041059
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[76].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[77].name
+      value: TestingUnity (320039298)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[77].uri
+      value: /videos/320039298
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[77].id
+      value: 320039298
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[77].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[78].name
+      value: UnityLiveStreamingTestUsingLibx264 (320024479)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[78].uri
+      value: /videos/320024479
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[78].id
+      value: 320024479
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[78].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[79].name
+      value: UnityStreamingTest (319996562)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[79].uri
+      value: /videos/319996562
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[79].id
+      value: 319996562
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[79].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[80].name
+      value: Streaming_Desktop_Screen_From_CLI (319954329)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[80].uri
+      value: /videos/319954329
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[80].id
+      value: 319954329
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[80].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[81].name
+      value: Testing FFMPEG CLI streaming (319948301)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[81].uri
+      value: /videos/319948301
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[81].id
+      value: 319948301
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[81].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[82].name
+      value: Testing Livestreaming From Unity (319938732)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[82].uri
+      value: /videos/319938732
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[82].id
+      value: 319938732
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[82].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[83].name
+      value: Ford Focus AR (319537544)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[83].uri
+      value: /videos/319537544
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[83].id
+      value: 319537544
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[83].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[84].name
+      value: Large file test (WindowsEditor 2018.2.18f1) (317335709)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[84].uri
+      value: /videos/317335709
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[84].id
+      value: 317335709
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[84].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[85].name
+      value: Folder Test (WindowsEditor 2018.2.18f1) (317335632)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[85].uri
+      value: /videos/317335632
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[85].id
+      value: 317335632
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[85].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[86].name
+      value: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317335616)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[86].uri
+      value: /videos/317335616
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[86].id
+      value: 317335616
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[86].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[87].name
+      value: 'Multi Upload Test #1 (WindowsEditor 2018.2.18f1) (317335599)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[87].uri
+      value: /videos/317335599
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[87].id
+      value: 317335599
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[87].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[88].name
+      value: Screen Test (WindowsEditor 2018.2.18f1) (317335583)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[88].uri
+      value: /videos/317335583
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[88].id
+      value: 317335583
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[88].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[89].name
+      value: MainCamera Test (WindowsEditor 2018.2.18f1) (317335559)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[89].uri
+      value: /videos/317335559
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[89].id
+      value: 317335559
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[89].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[90].name
+      value: Multi Chunk Test (WindowsEditor 2018.2.18f1) (317335515)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[90].uri
+      value: /videos/317335515
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[90].id
+      value: 317335515
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[90].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[91].name
+      value: Large file test (WindowsEditor 2017.4.16f1) (317330379)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[91].uri
+      value: /videos/317330379
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[91].id
+      value: 317330379
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[91].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[92].name
+      value: Folder Test (WindowsEditor 2017.4.16f1) (317330369)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[92].uri
+      value: /videos/317330369
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[92].id
+      value: 317330369
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[92].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[93].name
+      value: 'Multi Upload Test #2 (WindowsEditor 2017.4.16f1) (317330353)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[93].uri
+      value: /videos/317330353
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[93].id
+      value: 317330353
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[93].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[94].name
+      value: 'Multi Upload Test #1 (WindowsEditor 2017.4.16f1) (317330327)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[94].uri
+      value: /videos/317330327
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[94].id
+      value: 317330327
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[94].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[95].name
+      value: Screen Test (WindowsEditor 2017.4.16f1) (317330297)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[95].uri
+      value: /videos/317330297
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[95].id
+      value: 317330297
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[95].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[96].name
+      value: MainCamera Test (WindowsEditor 2017.4.16f1) (317330257)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[96].uri
+      value: /videos/317330257
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[96].id
+      value: 317330257
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[96].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[97].name
+      value: Multi Chunk Test (WindowsEditor 2017.4.16f1) (317330200)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[97].uri
+      value: /videos/317330200
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[97].id
+      value: 317330200
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[97].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[98].name
+      value: Large file test (WindowsEditor 5.6.4f1) (317329709)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[98].uri
+      value: /videos/317329709
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[98].id
+      value: 317329709
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[98].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[99].name
+      value: Folder Test (WindowsEditor 2018.2.18f1) (317329134)
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[99].uri
+      value: /videos/317329134
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[99].id
+      value: 317329134
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[99].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[100].name
+      value: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317329103)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[100].uri
+      value: /videos/317329103
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[100].id
+      value: 317329103
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideos.Array.data[100].stereoFormat
+      value: mono
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: vimeoVideoId
+      value: 329210455
+      objectReference: {fileID: 0}
+    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
+        type: 3}
+      propertyPath: audioSource
+      value: 
+      objectReference: {fileID: 261259562}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 9ba9537c00e62a34bbb9071dfed6399d, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 9ba9537c00e62a34bbb9071dfed6399d, type: 3}
 --- !u!1 &261259556
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 261259561}
   - component: {fileID: 261259560}
   - component: {fileID: 261259559}
   - component: {fileID: 261259558}
   - component: {fileID: 261259557}
+  - component: {fileID: 261259562}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -260,34 +2413,44 @@ GameObject:
 --- !u!81 &261259557
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 261259556}
   m_Enabled: 1
 --- !u!124 &261259558
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 261259556}
   m_Enabled: 1
 --- !u!92 &261259559
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 261259556}
   m_Enabled: 1
 --- !u!20 &261259560
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 261259556}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -317,8 +2480,9 @@ Camera:
 --- !u!4 &261259561
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 261259556}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.18, y: 0, z: -10}
@@ -327,3 +2491,99 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &261259562
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 261259556}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Vimeo/Scenes/CanvasPlayer.unity
+++ b/Assets/Vimeo/Scenes/CanvasPlayer.unity
@@ -120,2275 +120,192 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &240301501
-PrefabInstance:
+--- !u!1 &185420691
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224225937751239816, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224921726650614060, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224921726650614060, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224099595188191770, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.size
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.size
-      value: 101
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: uid
-      value: 6b82e032-b17f-4cab-a22c-fa15545b9ce5
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoToken
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoSignIn
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[0].name
-      value: '---- Find a video ----'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentFolder.name
-      value: Most recent videos
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[1].name
-      value: Get video by ID or URL
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[1].uri
-      value: custom
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[2].name
-      value: Most recent videos
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[2].uri
-      value: recent
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[3].name
-      value: Projects / Inside Vimeo
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[3].uri
-      value: /users/10945988/projects/438887
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[3].id
-      value: 438887
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[4].name
-      value: Projects / Looking Glass
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[4].uri
-      value: /users/10945988/projects/510800
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[4].id
-      value: 510800
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[5].name
-      value: Projects / Unity Tests
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[5].uri
-      value: /users/10945988/projects/640966
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoFolders.Array.data[5].id
-      value: 640966
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[0].name
-      value: '---- Select a video ----'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[0].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentFolder.uri
-      value: recent
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentVideo.name
-      value: Glitch (329210455)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentVideo.uri
-      value: /videos/329210455
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentVideo.id
-      value: 329210455
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: currentVideo.stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[1].name
-      value: Vimeo OFFF Projection Mapping (331447933)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[1].uri
-      value: /videos/331447933
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[1].id
-      value: 331447933
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[1].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[2].name
-      value: Bubbles (331319640)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[2].uri
-      value: /videos/331319640
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[2].id
-      value: 331319640
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[2].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[3].name
-      value: Vimeo_OFFF_Rooms_v2 (331251315)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[3].uri
-      value: /videos/331251315
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[3].id
-      value: 331251315
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[3].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[4].name
-      value: Vimeo_OFFF_Bubbles_v2 (331250140)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[4].uri
-      value: /videos/331250140
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[4].id
-      value: 331250140
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[4].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[5].name
-      value: Vimeo_OFFF_Glitch_v2 (331247618)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[5].uri
-      value: /videos/331247618
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[5].id
-      value: 331247618
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[5].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[6].name
-      value: Vimeo_OFFF_Ariel_v2 (331246689)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[6].uri
-      value: /videos/331246689
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[6].id
-      value: 331246689
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[6].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[7].name
-      value: Synth.io WIP Walkthrough (330682435)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[7].uri
-      value: /videos/330682435
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[7].id
-      value: 330682435
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[7].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[8].name
-      value: 360 (329630274)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[8].uri
-      value: /videos/329630274
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[8].id
-      value: 329630274
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[8].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[9].name
-      value: Vimeo - OFFF Projection Mapping Test (329214614)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[9].uri
-      value: /videos/329214614
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[9].id
-      value: 329214614
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[9].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[10].name
-      value: Rooms (329210480)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[10].uri
-      value: /videos/329210480
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[10].id
-      value: 329210480
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[10].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[11].name
-      value: Glitch (329210455)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[11].uri
-      value: /videos/329210455
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[11].id
-      value: 329210455
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[11].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[12].name
-      value: Bubbles (329210391)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[12].uri
-      value: /videos/329210391
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[12].id
-      value: 329210391
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[12].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[13].name
-      value: Ariel (329210310)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[13].uri
-      value: /videos/329210310
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[13].id
-      value: 329210310
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[13].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[14].name
-      value: 'Vimeo OFFF New Fabrication Mockup #1 (328747593)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[14].uri
-      value: /videos/328747593
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[14].id
-      value: 328747593
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[14].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[15].name
-      value: test (328572534)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[15].uri
-      value: /videos/328572534
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[15].id
-      value: 328572534
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[15].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[16].name
-      value: Vimeo OFFF test (328257415)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[16].uri
-      value: /videos/328257415
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[16].id
-      value: 328257415
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[16].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[17].name
-      value: Low poly logo (327781516)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[17].uri
-      value: /videos/327781516
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[17].id
-      value: 327781516
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[17].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[18].name
-      value: LKG Vimeo (326681809)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[18].uri
-      value: /videos/326681809
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[18].id
-      value: 326681809
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[18].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[19].name
-      value: Large file test (OSXEditor 2017.1.4f1) (326420860)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[19].uri
-      value: /videos/326420860
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[19].id
-      value: 326420860
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[19].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[20].name
-      value: Large file test (OSXEditor 2018.3.6f1) (326418690)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[20].uri
-      value: /videos/326418690
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[20].id
-      value: 326418690
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[20].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[21].name
-      value: Folder Test (OSXEditor 2018.3.6f1) (326418591)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[21].uri
-      value: /videos/326418591
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[21].id
-      value: 326418591
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[21].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[22].name
-      value: 'Multi Upload Test #2 (OSXEditor 2018.3.6f1) (326418559)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[22].uri
-      value: /videos/326418559
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[22].id
-      value: 326418559
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[22].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[23].name
-      value: 'Multi Upload Test #1 (OSXEditor 2018.3.6f1) (326418535)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[23].uri
-      value: /videos/326418535
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[23].id
-      value: 326418535
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[23].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[24].name
-      value: Screen Test (OSXEditor 2018.3.6f1) (326418508)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[24].uri
-      value: /videos/326418508
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[24].id
-      value: 326418508
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[24].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[25].name
-      value: MainCamera Test (OSXEditor 2018.3.6f1) (326418468)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[25].uri
-      value: /videos/326418468
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[25].id
-      value: 326418468
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[25].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[26].name
-      value: Multi Chunk Test (OSXEditor 2018.3.6f1) (326418417)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[26].uri
-      value: /videos/326418417
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[26].id
-      value: 326418417
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[26].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[27].name
-      value: Folder Test (OSXEditor 2018.2.14f1) (326417432)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[27].uri
-      value: /videos/326417432
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[27].id
-      value: 326417432
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[27].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[28].name
-      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (326417391)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[28].uri
-      value: /videos/326417391
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[28].id
-      value: 326417391
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[28].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[29].name
-      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326417357)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[29].uri
-      value: /videos/326417357
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[29].id
-      value: 326417357
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[29].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[30].name
-      value: Screen Test (OSXEditor 2018.2.14f1) (326417326)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[30].uri
-      value: /videos/326417326
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[30].id
-      value: 326417326
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[30].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[31].name
-      value: MainCamera Test (OSXEditor 2018.2.14f1) (326417300)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[31].uri
-      value: /videos/326417300
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[31].id
-      value: 326417300
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[31].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[32].name
-      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (326417243)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[32].uri
-      value: /videos/326417243
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[32].id
-      value: 326417243
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[32].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[33].name
-      value: Large file test (OSXEditor 2018.2.14f1) (326417155)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[33].uri
-      value: /videos/326417155
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[33].id
-      value: 326417155
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[33].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[34].name
-      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326416974)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[34].uri
-      value: /videos/326416974
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[34].id
-      value: 326416974
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[34].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[35].name
-      value: MainCamera Test (OSXEditor 2018.2.14f1) (326416679)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[35].uri
-      value: /videos/326416679
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[35].id
-      value: 326416679
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[35].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[36].name
-      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (326416644)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[36].uri
-      value: /videos/326416644
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[36].id
-      value: 326416644
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[36].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[37].name
-      value: Folder Test (OSXEditor 2018.2.14f1) (325672606)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[37].uri
-      value: /videos/325672606
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[37].id
-      value: 325672606
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[37].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[38].name
-      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (325672569)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[38].uri
-      value: /videos/325672569
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[38].id
-      value: 325672569
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[38].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[39].name
-      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (325672545)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[39].uri
-      value: /videos/325672545
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[39].id
-      value: 325672545
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[39].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[40].name
-      value: Screen Test (OSXEditor 2018.2.14f1) (325672506)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[40].uri
-      value: /videos/325672506
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[40].id
-      value: 325672506
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[40].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[41].name
-      value: MainCamera Test (OSXEditor 2018.2.14f1) (325672467)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[41].uri
-      value: /videos/325672467
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[41].id
-      value: 325672467
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[41].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[42].name
-      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (325672405)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[42].uri
-      value: /videos/325672405
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[42].id
-      value: 325672405
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[42].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[43].name
-      value: Birthday (324001683)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[43].uri
-      value: /videos/324001683
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[43].id
-      value: 324001683
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[43].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[44].name
-      value: Bi (324001682)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[44].uri
-      value: /videos/324001682
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[44].id
-      value: 324001682
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[44].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[45].name
-      value: test4 (324001681)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[45].uri
-      value: /videos/324001681
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[45].id
-      value: 324001681
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[45].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[46].name
-      value: Cake (324001405)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[46].uri
-      value: /videos/324001405
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[46].id
-      value: 324001405
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[46].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[47].name
-      value: Untitled (323997910)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[47].uri
-      value: /videos/323997910
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[47].id
-      value: 323997910
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[47].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[48].name
-      value: Race (323997909)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[48].uri
-      value: /videos/323997909
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[48].id
-      value: 323997909
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[48].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[49].name
-      value: race (323997908)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[49].uri
-      value: /videos/323997908
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[49].id
-      value: 323997908
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[49].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[50].name
-      value: Travel (323997660)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[50].uri
-      value: /videos/323997660
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[50].id
-      value: 323997660
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[50].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[51].name
-      value: Hip (323997309)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[51].uri
-      value: /videos/323997309
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[51].id
-      value: 323997309
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[51].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[52].name
-      value: travel (323997192)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[52].uri
-      value: /videos/323997192
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[52].id
-      value: 323997192
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[52].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[53].name
-      value: Auto generated marketing video - Bike Shop (v1) (323794820)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[53].uri
-      value: /videos/323794820
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[53].id
-      value: 323794820
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[53].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[54].name
-      value: itp   U+1F354 (322063174)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[54].uri
-      value: /videos/322063174
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[54].id
-      value: 322063174
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[54].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[55].name
-      value: TestEventThinko (321767823)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[55].uri
-      value: /videos/321767823
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[55].id
-      value: 321767823
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[55].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[56].name
-      value: Folder Test (OSXEditor 2018.2.14f1) (321529342)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[56].uri
-      value: /videos/321529342
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[56].id
-      value: 321529342
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[56].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[57].name
-      value: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (321529316)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[57].uri
-      value: /videos/321529316
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[57].id
-      value: 321529316
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[57].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[58].name
-      value: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (321529291)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[58].uri
-      value: /videos/321529291
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[58].id
-      value: 321529291
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[58].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[59].name
-      value: Screen Test (OSXEditor 2018.2.14f1) (321529263)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[59].uri
-      value: /videos/321529263
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[59].id
-      value: 321529263
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[59].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[60].name
-      value: MainCamera Test (OSXEditor 2018.2.14f1) (321529226)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[60].uri
-      value: /videos/321529226
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[60].id
-      value: 321529226
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[60].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[61].name
-      value: Multi Chunk Test (OSXEditor 2018.2.14f1) (321529178)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[61].uri
-      value: /videos/321529178
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[61].id
-      value: 321529178
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[61].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[62].name
-      value: New Unity Recorder Test (321517785)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[62].uri
-      value: /videos/321517785
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[62].id
-      value: 321517785
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[62].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[63].name
-      value: testStreamFromAPI (320531441)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[63].uri
-      value: /videos/320531441
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[63].id
-      value: 320531441
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[63].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[64].name
-      value: testStreamFromAPI (320527769)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[64].uri
-      value: /videos/320527769
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[64].id
-      value: 320527769
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[64].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[65].name
-      value: testEvent (320526358)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[65].uri
-      value: /videos/320526358
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[65].id
-      value: 320526358
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[65].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[66].name
-      value: testEvent (320517114)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[66].uri
-      value: /videos/320517114
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[66].id
-      value: 320517114
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[66].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[67].name
-      value: Creating Live event from an API request (320370706)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[67].uri
-      value: /videos/320370706
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[67].id
-      value: 320370706
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[67].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[68].name
-      value: Second test with Kenya (320364272)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[68].uri
-      value: /videos/320364272
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[68].id
-      value: 320364272
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[68].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[69].name
-      value: Testing with Kenya creating a live event (320363254)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[69].uri
-      value: /videos/320363254
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[69].id
-      value: 320363254
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[69].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[70].name
-      value: Untitled (320297769)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[70].uri
-      value: /videos/320297769
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[70].id
-      value: 320297769
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[70].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[71].name
-      value: Untitled (320297659)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[71].uri
-      value: /videos/320297659
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[71].id
-      value: 320297659
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[71].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[72].name
-      value: UnityLiveStreamTest - Long Shot Camera (320292249)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[72].uri
-      value: /videos/320292249
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[72].id
-      value: 320292249
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[72].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[73].name
-      value: UnityLiveStreamTest - Side Shot Camera (320292011)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[73].uri
-      value: /videos/320292011
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[73].id
-      value: 320292011
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[73].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[74].name
-      value: UnityLiveStreamTest - Close Up Camera (320291760)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[74].uri
-      value: /videos/320291760
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[74].id
-      value: 320291760
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[74].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[75].name
-      value: WindowsUnityLivestreamTest (320266469)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[75].uri
-      value: /videos/320266469
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[75].id
-      value: 320266469
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[75].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[76].name
-      value: Live Streaming from a Unity camera to the iOS Vimeo app (320041059)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[76].uri
-      value: /videos/320041059
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[76].id
-      value: 320041059
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[76].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[77].name
-      value: TestingUnity (320039298)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[77].uri
-      value: /videos/320039298
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[77].id
-      value: 320039298
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[77].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[78].name
-      value: UnityLiveStreamingTestUsingLibx264 (320024479)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[78].uri
-      value: /videos/320024479
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[78].id
-      value: 320024479
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[78].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[79].name
-      value: UnityStreamingTest (319996562)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[79].uri
-      value: /videos/319996562
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[79].id
-      value: 319996562
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[79].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[80].name
-      value: Streaming_Desktop_Screen_From_CLI (319954329)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[80].uri
-      value: /videos/319954329
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[80].id
-      value: 319954329
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[80].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[81].name
-      value: Testing FFMPEG CLI streaming (319948301)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[81].uri
-      value: /videos/319948301
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[81].id
-      value: 319948301
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[81].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[82].name
-      value: Testing Livestreaming From Unity (319938732)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[82].uri
-      value: /videos/319938732
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[82].id
-      value: 319938732
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[82].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[83].name
-      value: Ford Focus AR (319537544)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[83].uri
-      value: /videos/319537544
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[83].id
-      value: 319537544
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[83].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[84].name
-      value: Large file test (WindowsEditor 2018.2.18f1) (317335709)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[84].uri
-      value: /videos/317335709
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[84].id
-      value: 317335709
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[84].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[85].name
-      value: Folder Test (WindowsEditor 2018.2.18f1) (317335632)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[85].uri
-      value: /videos/317335632
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[85].id
-      value: 317335632
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[85].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[86].name
-      value: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317335616)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[86].uri
-      value: /videos/317335616
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[86].id
-      value: 317335616
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[86].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[87].name
-      value: 'Multi Upload Test #1 (WindowsEditor 2018.2.18f1) (317335599)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[87].uri
-      value: /videos/317335599
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[87].id
-      value: 317335599
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[87].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[88].name
-      value: Screen Test (WindowsEditor 2018.2.18f1) (317335583)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[88].uri
-      value: /videos/317335583
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[88].id
-      value: 317335583
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[88].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[89].name
-      value: MainCamera Test (WindowsEditor 2018.2.18f1) (317335559)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[89].uri
-      value: /videos/317335559
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[89].id
-      value: 317335559
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[89].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[90].name
-      value: Multi Chunk Test (WindowsEditor 2018.2.18f1) (317335515)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[90].uri
-      value: /videos/317335515
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[90].id
-      value: 317335515
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[90].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[91].name
-      value: Large file test (WindowsEditor 2017.4.16f1) (317330379)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[91].uri
-      value: /videos/317330379
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[91].id
-      value: 317330379
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[91].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[92].name
-      value: Folder Test (WindowsEditor 2017.4.16f1) (317330369)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[92].uri
-      value: /videos/317330369
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[92].id
-      value: 317330369
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[92].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[93].name
-      value: 'Multi Upload Test #2 (WindowsEditor 2017.4.16f1) (317330353)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[93].uri
-      value: /videos/317330353
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[93].id
-      value: 317330353
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[93].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[94].name
-      value: 'Multi Upload Test #1 (WindowsEditor 2017.4.16f1) (317330327)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[94].uri
-      value: /videos/317330327
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[94].id
-      value: 317330327
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[94].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[95].name
-      value: Screen Test (WindowsEditor 2017.4.16f1) (317330297)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[95].uri
-      value: /videos/317330297
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[95].id
-      value: 317330297
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[95].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[96].name
-      value: MainCamera Test (WindowsEditor 2017.4.16f1) (317330257)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[96].uri
-      value: /videos/317330257
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[96].id
-      value: 317330257
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[96].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[97].name
-      value: Multi Chunk Test (WindowsEditor 2017.4.16f1) (317330200)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[97].uri
-      value: /videos/317330200
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[97].id
-      value: 317330200
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[97].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[98].name
-      value: Large file test (WindowsEditor 5.6.4f1) (317329709)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[98].uri
-      value: /videos/317329709
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[98].id
-      value: 317329709
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[98].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[99].name
-      value: Folder Test (WindowsEditor 2018.2.18f1) (317329134)
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[99].uri
-      value: /videos/317329134
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[99].id
-      value: 317329134
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[99].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[100].name
-      value: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317329103)'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[100].uri
-      value: /videos/317329103
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[100].id
-      value: 317329103
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideos.Array.data[100].stereoFormat
-      value: mono
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: vimeoVideoId
-      value: 329210455
-      objectReference: {fileID: 0}
-    - target: {fileID: 114552117194758444, guid: 9ba9537c00e62a34bbb9071dfed6399d,
-        type: 3}
-      propertyPath: audioSource
-      value: 
-      objectReference: {fileID: 261259562}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9ba9537c00e62a34bbb9071dfed6399d, type: 3}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 185420692}
+  - component: {fileID: 185420694}
+  - component: {fileID: 185420693}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &185420692
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185420691}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 447781896}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &185420693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185420691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Pause
+
+'
+--- !u!222 &185420694
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185420691}
+  m_CullTransparentMesh: 0
+--- !u!1 &203043510
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 203043511}
+  - component: {fileID: 203043513}
+  - component: {fileID: 203043512}
+  m_Layer: 0
+  m_Name: SeekBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &203043511
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203043510}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2094302229}
+  - {fileID: 538509767}
+  - {fileID: 360666735}
+  m_Father: {fileID: 318930917}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 135.27, y: 30.5}
+  m_SizeDelta: {x: -156.87001, y: 20}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &203043512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203043510}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72a7510b4e60d4e4dbcbecb4b2d307f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vimeoPlayer: {fileID: 318930912}
+--- !u!114 &203043513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203043510}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -113659843, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1987208709}
+  m_FillRect: {fileID: 820448720}
+  m_HandleRect: {fileID: 1987208708}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.145
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!1 &261259556
 GameObject:
   m_ObjectHideFlags: 0
@@ -2403,6 +320,7 @@ GameObject:
   - component: {fileID: 261259558}
   - component: {fileID: 261259557}
   - component: {fileID: 261259562}
+  - component: {fileID: 261259563}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2587,3 +505,1989 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!82 &261259563
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 261259556}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!1 &318930911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 318930917}
+  - component: {fileID: 318930916}
+  - component: {fileID: 318930915}
+  - component: {fileID: 318930914}
+  - component: {fileID: 318930913}
+  - component: {fileID: 318930912}
+  m_Layer: 0
+  m_Name: '[VimeoPlayerCanvas]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 2800000, guid: f769f33aff14dac43a5e2a682eaf1b33, type: 3}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &318930912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7174a652004baed43b39101d78c36e46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uid: 0fc7f924-6a62-403c-bafc-30333e0c9c8e
+  currentVideo:
+    name: Glitch (329210455)
+    uri: /videos/329210455
+    tusUploadLink: 
+    id: 329210455
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  vimeoVideos:
+  - name: '---- Select a video ----'
+    uri: 
+    tusUploadLink: 
+    id: 0
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo OFFF Projection Mapping (331447933)
+    uri: /videos/331447933
+    tusUploadLink: 
+    id: 331447933
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Bubbles (331319640)
+    uri: /videos/331319640
+    tusUploadLink: 
+    id: 331319640
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo_OFFF_Rooms_v2 (331251315)
+    uri: /videos/331251315
+    tusUploadLink: 
+    id: 331251315
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo_OFFF_Bubbles_v2 (331250140)
+    uri: /videos/331250140
+    tusUploadLink: 
+    id: 331250140
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo_OFFF_Glitch_v2 (331247618)
+    uri: /videos/331247618
+    tusUploadLink: 
+    id: 331247618
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo_OFFF_Ariel_v2 (331246689)
+    uri: /videos/331246689
+    tusUploadLink: 
+    id: 331246689
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Synth.io WIP Walkthrough (330682435)
+    uri: /videos/330682435
+    tusUploadLink: 
+    id: 330682435
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 360 (329630274)
+    uri: /videos/329630274
+    tusUploadLink: 
+    id: 329630274
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo - OFFF Projection Mapping Test (329214614)
+    uri: /videos/329214614
+    tusUploadLink: 
+    id: 329214614
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Rooms (329210480)
+    uri: /videos/329210480
+    tusUploadLink: 
+    id: 329210480
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Glitch (329210455)
+    uri: /videos/329210455
+    tusUploadLink: 
+    id: 329210455
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Bubbles (329210391)
+    uri: /videos/329210391
+    tusUploadLink: 
+    id: 329210391
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Ariel (329210310)
+    uri: /videos/329210310
+    tusUploadLink: 
+    id: 329210310
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Vimeo OFFF New Fabrication Mockup #1 (328747593)'
+    uri: /videos/328747593
+    tusUploadLink: 
+    id: 328747593
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: test (328572534)
+    uri: /videos/328572534
+    tusUploadLink: 
+    id: 328572534
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Vimeo OFFF test (328257415)
+    uri: /videos/328257415
+    tusUploadLink: 
+    id: 328257415
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Low poly logo (327781516)
+    uri: /videos/327781516
+    tusUploadLink: 
+    id: 327781516
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: LKG Vimeo (326681809)
+    uri: /videos/326681809
+    tusUploadLink: 
+    id: 326681809
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (OSXEditor 2017.1.4f1) (326420860)
+    uri: /videos/326420860
+    tusUploadLink: 
+    id: 326420860
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (OSXEditor 2018.3.6f1) (326418690)
+    uri: /videos/326418690
+    tusUploadLink: 
+    id: 326418690
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (OSXEditor 2018.3.6f1) (326418591)
+    uri: /videos/326418591
+    tusUploadLink: 
+    id: 326418591
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (OSXEditor 2018.3.6f1) (326418559)'
+    uri: /videos/326418559
+    tusUploadLink: 
+    id: 326418559
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (OSXEditor 2018.3.6f1) (326418535)'
+    uri: /videos/326418535
+    tusUploadLink: 
+    id: 326418535
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (OSXEditor 2018.3.6f1) (326418508)
+    uri: /videos/326418508
+    tusUploadLink: 
+    id: 326418508
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (OSXEditor 2018.3.6f1) (326418468)
+    uri: /videos/326418468
+    tusUploadLink: 
+    id: 326418468
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (OSXEditor 2018.3.6f1) (326418417)
+    uri: /videos/326418417
+    tusUploadLink: 
+    id: 326418417
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (OSXEditor 2018.2.14f1) (326417432)
+    uri: /videos/326417432
+    tusUploadLink: 
+    id: 326417432
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (326417391)'
+    uri: /videos/326417391
+    tusUploadLink: 
+    id: 326417391
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326417357)'
+    uri: /videos/326417357
+    tusUploadLink: 
+    id: 326417357
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (OSXEditor 2018.2.14f1) (326417326)
+    uri: /videos/326417326
+    tusUploadLink: 
+    id: 326417326
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (OSXEditor 2018.2.14f1) (326417300)
+    uri: /videos/326417300
+    tusUploadLink: 
+    id: 326417300
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (OSXEditor 2018.2.14f1) (326417243)
+    uri: /videos/326417243
+    tusUploadLink: 
+    id: 326417243
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (OSXEditor 2018.2.14f1) (326417155)
+    uri: /videos/326417155
+    tusUploadLink: 
+    id: 326417155
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (326416974)'
+    uri: /videos/326416974
+    tusUploadLink: 
+    id: 326416974
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (OSXEditor 2018.2.14f1) (326416679)
+    uri: /videos/326416679
+    tusUploadLink: 
+    id: 326416679
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (OSXEditor 2018.2.14f1) (326416644)
+    uri: /videos/326416644
+    tusUploadLink: 
+    id: 326416644
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (OSXEditor 2018.2.14f1) (325672606)
+    uri: /videos/325672606
+    tusUploadLink: 
+    id: 325672606
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (325672569)'
+    uri: /videos/325672569
+    tusUploadLink: 
+    id: 325672569
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (325672545)'
+    uri: /videos/325672545
+    tusUploadLink: 
+    id: 325672545
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (OSXEditor 2018.2.14f1) (325672506)
+    uri: /videos/325672506
+    tusUploadLink: 
+    id: 325672506
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (OSXEditor 2018.2.14f1) (325672467)
+    uri: /videos/325672467
+    tusUploadLink: 
+    id: 325672467
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (OSXEditor 2018.2.14f1) (325672405)
+    uri: /videos/325672405
+    tusUploadLink: 
+    id: 325672405
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Birthday (324001683)
+    uri: /videos/324001683
+    tusUploadLink: 
+    id: 324001683
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Bi (324001682)
+    uri: /videos/324001682
+    tusUploadLink: 
+    id: 324001682
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: test4 (324001681)
+    uri: /videos/324001681
+    tusUploadLink: 
+    id: 324001681
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Cake (324001405)
+    uri: /videos/324001405
+    tusUploadLink: 
+    id: 324001405
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Untitled (323997910)
+    uri: /videos/323997910
+    tusUploadLink: 
+    id: 323997910
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Race (323997909)
+    uri: /videos/323997909
+    tusUploadLink: 
+    id: 323997909
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: race (323997908)
+    uri: /videos/323997908
+    tusUploadLink: 
+    id: 323997908
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Travel (323997660)
+    uri: /videos/323997660
+    tusUploadLink: 
+    id: 323997660
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Hip (323997309)
+    uri: /videos/323997309
+    tusUploadLink: 
+    id: 323997309
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: travel (323997192)
+    uri: /videos/323997192
+    tusUploadLink: 
+    id: 323997192
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Auto generated marketing video - Bike Shop (v1) (323794820)
+    uri: /videos/323794820
+    tusUploadLink: 
+    id: 323794820
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: itp   U+1F354 (322063174)
+    uri: /videos/322063174
+    tusUploadLink: 
+    id: 322063174
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: TestEventThinko (321767823)
+    uri: /videos/321767823
+    tusUploadLink: 
+    id: 321767823
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (OSXEditor 2018.2.14f1) (321529342)
+    uri: /videos/321529342
+    tusUploadLink: 
+    id: 321529342
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (OSXEditor 2018.2.14f1) (321529316)'
+    uri: /videos/321529316
+    tusUploadLink: 
+    id: 321529316
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (OSXEditor 2018.2.14f1) (321529291)'
+    uri: /videos/321529291
+    tusUploadLink: 
+    id: 321529291
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (OSXEditor 2018.2.14f1) (321529263)
+    uri: /videos/321529263
+    tusUploadLink: 
+    id: 321529263
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (OSXEditor 2018.2.14f1) (321529226)
+    uri: /videos/321529226
+    tusUploadLink: 
+    id: 321529226
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (OSXEditor 2018.2.14f1) (321529178)
+    uri: /videos/321529178
+    tusUploadLink: 
+    id: 321529178
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: New Unity Recorder Test (321517785)
+    uri: /videos/321517785
+    tusUploadLink: 
+    id: 321517785
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: testStreamFromAPI (320531441)
+    uri: /videos/320531441
+    tusUploadLink: 
+    id: 320531441
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: testStreamFromAPI (320527769)
+    uri: /videos/320527769
+    tusUploadLink: 
+    id: 320527769
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: testEvent (320526358)
+    uri: /videos/320526358
+    tusUploadLink: 
+    id: 320526358
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: testEvent (320517114)
+    uri: /videos/320517114
+    tusUploadLink: 
+    id: 320517114
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Creating Live event from an API request (320370706)
+    uri: /videos/320370706
+    tusUploadLink: 
+    id: 320370706
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Second test with Kenya (320364272)
+    uri: /videos/320364272
+    tusUploadLink: 
+    id: 320364272
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Testing with Kenya creating a live event (320363254)
+    uri: /videos/320363254
+    tusUploadLink: 
+    id: 320363254
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Untitled (320297769)
+    uri: /videos/320297769
+    tusUploadLink: 
+    id: 320297769
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Untitled (320297659)
+    uri: /videos/320297659
+    tusUploadLink: 
+    id: 320297659
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: UnityLiveStreamTest - Long Shot Camera (320292249)
+    uri: /videos/320292249
+    tusUploadLink: 
+    id: 320292249
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: UnityLiveStreamTest - Side Shot Camera (320292011)
+    uri: /videos/320292011
+    tusUploadLink: 
+    id: 320292011
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: UnityLiveStreamTest - Close Up Camera (320291760)
+    uri: /videos/320291760
+    tusUploadLink: 
+    id: 320291760
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: WindowsUnityLivestreamTest (320266469)
+    uri: /videos/320266469
+    tusUploadLink: 
+    id: 320266469
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Live Streaming from a Unity camera to the iOS Vimeo app (320041059)
+    uri: /videos/320041059
+    tusUploadLink: 
+    id: 320041059
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: TestingUnity (320039298)
+    uri: /videos/320039298
+    tusUploadLink: 
+    id: 320039298
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: UnityLiveStreamingTestUsingLibx264 (320024479)
+    uri: /videos/320024479
+    tusUploadLink: 
+    id: 320024479
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: UnityStreamingTest (319996562)
+    uri: /videos/319996562
+    tusUploadLink: 
+    id: 319996562
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Streaming_Desktop_Screen_From_CLI (319954329)
+    uri: /videos/319954329
+    tusUploadLink: 
+    id: 319954329
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Testing FFMPEG CLI streaming (319948301)
+    uri: /videos/319948301
+    tusUploadLink: 
+    id: 319948301
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Testing Livestreaming From Unity (319938732)
+    uri: /videos/319938732
+    tusUploadLink: 
+    id: 319938732
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Ford Focus AR (319537544)
+    uri: /videos/319537544
+    tusUploadLink: 
+    id: 319537544
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (WindowsEditor 2018.2.18f1) (317335709)
+    uri: /videos/317335709
+    tusUploadLink: 
+    id: 317335709
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (WindowsEditor 2018.2.18f1) (317335632)
+    uri: /videos/317335632
+    tusUploadLink: 
+    id: 317335632
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317335616)'
+    uri: /videos/317335616
+    tusUploadLink: 
+    id: 317335616
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (WindowsEditor 2018.2.18f1) (317335599)'
+    uri: /videos/317335599
+    tusUploadLink: 
+    id: 317335599
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (WindowsEditor 2018.2.18f1) (317335583)
+    uri: /videos/317335583
+    tusUploadLink: 
+    id: 317335583
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (WindowsEditor 2018.2.18f1) (317335559)
+    uri: /videos/317335559
+    tusUploadLink: 
+    id: 317335559
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (WindowsEditor 2018.2.18f1) (317335515)
+    uri: /videos/317335515
+    tusUploadLink: 
+    id: 317335515
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (WindowsEditor 2017.4.16f1) (317330379)
+    uri: /videos/317330379
+    tusUploadLink: 
+    id: 317330379
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (WindowsEditor 2017.4.16f1) (317330369)
+    uri: /videos/317330369
+    tusUploadLink: 
+    id: 317330369
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (WindowsEditor 2017.4.16f1) (317330353)'
+    uri: /videos/317330353
+    tusUploadLink: 
+    id: 317330353
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #1 (WindowsEditor 2017.4.16f1) (317330327)'
+    uri: /videos/317330327
+    tusUploadLink: 
+    id: 317330327
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Screen Test (WindowsEditor 2017.4.16f1) (317330297)
+    uri: /videos/317330297
+    tusUploadLink: 
+    id: 317330297
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: MainCamera Test (WindowsEditor 2017.4.16f1) (317330257)
+    uri: /videos/317330257
+    tusUploadLink: 
+    id: 317330257
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Multi Chunk Test (WindowsEditor 2017.4.16f1) (317330200)
+    uri: /videos/317330200
+    tusUploadLink: 
+    id: 317330200
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Large file test (WindowsEditor 5.6.4f1) (317329709)
+    uri: /videos/317329709
+    tusUploadLink: 
+    id: 317329709
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: Folder Test (WindowsEditor 2018.2.18f1) (317329134)
+    uri: /videos/317329134
+    tusUploadLink: 
+    id: 317329134
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  - name: 'Multi Upload Test #2 (WindowsEditor 2018.2.18f1) (317329103)'
+    uri: /videos/317329103
+    tusUploadLink: 
+    id: 317329103
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: mono
+    projection: 
+  currentFolder:
+    name: Most recent videos
+    uri: recent
+    id: 0
+  vimeoFolders:
+  - name: '---- Find a video ----'
+    uri: 
+    id: 0
+  - name: Get video by ID or URL
+    uri: custom
+    id: 0
+  - name: Most recent videos
+    uri: recent
+    id: 0
+  - name: Projects / Inside Vimeo
+    uri: /users/10945988/projects/438887
+    id: 438887
+  - name: Projects / Looking Glass
+    uri: /users/10945988/projects/510800
+    id: 510800
+  - name: Projects / Unity Tests
+    uri: /users/10945988/projects/640966
+    id: 640966
+  vimeoToken: 
+  buildMode: 0
+  vimeoSignIn: 1
+  signInError: 0
+  videoPlayerType: 0
+  mediaPlayer: {fileID: 0}
+  selectedResolution: 2160
+  vimeoVideoId: 329210455
+  muteAudio: 0
+  autoPlay: 1
+  startTime: 0
+  videoScreen: {fileID: 1217564727}
+  audioSource: {fileID: 261259563}
+  videoName: 
+  videoThumbnailUrl: 
+  authorThumbnailUrl: 
+  is3D: 0
+  videoProjection: 
+  videoStereoFormat: 
+  controller: {fileID: 0}
+  vimeoVideo:
+    name: 
+    uri: 
+    tusUploadLink: 
+    id: 0
+    description: 
+    duration: 0
+    width: 0
+    height: 0
+    is3D: 0
+    stereoFormat: 
+    projection: 
+  loadingVideoMetadata: 0
+  m_file_url: 
+--- !u!114 &318930913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e00aecc43cb598e40b12efec445ac9f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  heightAxis: {x: 0, y: 1, z: 0}
+--- !u!114 &318930914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &318930915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &318930916
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 1
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &318930917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318930911}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1217564730}
+  - {fileID: 447781896}
+  - {fileID: 203043511}
+  - {fileID: 1216973306}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &360666734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 360666735}
+  m_Layer: 0
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &360666735
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 360666734}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1987208708}
+  m_Father: {fileID: 203043511}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &447781895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 447781896}
+  - component: {fileID: 447781900}
+  - component: {fileID: 447781899}
+  - component: {fileID: 447781898}
+  - component: {fileID: 447781897}
+  m_Layer: 0
+  m_Name: PlayButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &447781896
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447781895}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 185420692}
+  m_Father: {fileID: 318930917}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 69, y: 29.601562}
+  m_SizeDelta: {x: 93, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &447781897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447781895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d9516eb1c694ce74aacc7f618557bdaa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vimeoPlayer: {fileID: 318930912}
+  playButtonText: {fileID: 185420691}
+--- !u!114 &447781898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447781895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 447781899}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 318930912}
+        m_MethodName: ToggleVideoPlayback
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &447781899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447781895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &447781900
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447781895}
+  m_CullTransparentMesh: 0
+--- !u!1 &538509766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 538509767}
+  m_Layer: 0
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &538509767
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 538509766}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 820448720}
+  m_Father: {fileID: 203043511}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &820448719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 820448720}
+  - component: {fileID: 820448722}
+  - component: {fileID: 820448721}
+  m_Layer: 0
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &820448720
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820448719}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 538509767}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &820448721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820448719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &820448722
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820448719}
+  m_CullTransparentMesh: 0
+--- !u!1 &1216973305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1216973306}
+  - component: {fileID: 1216973308}
+  - component: {fileID: 1216973307}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1216973306
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216973305}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -405, y: -433.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 318930917}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1216973307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216973305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1216973308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1216973305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!1 &1217564727
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1217564730}
+  - component: {fileID: 1217564729}
+  - component: {fileID: 1217564728}
+  m_Layer: 0
+  m_Name: Screen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1217564728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217564727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1217564729
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217564727}
+  m_CullTransparentMesh: 0
+--- !u!224 &1217564730
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217564727}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 318930917}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1987208707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1987208708}
+  - component: {fileID: 1987208710}
+  - component: {fileID: 1987208709}
+  m_Layer: 0
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1987208708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987208707}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 360666735}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1987208709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987208707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &1987208710
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987208707}
+  m_CullTransparentMesh: 0
+--- !u!1 &2094302228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2094302229}
+  - component: {fileID: 2094302231}
+  - component: {fileID: 2094302230}
+  m_Layer: 0
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2094302229
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2094302228}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 203043511}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2094302230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2094302228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &2094302231
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2094302228}
+  m_CullTransparentMesh: 0

--- a/Assets/Vimeo/Scripts/Editor/VimeoPlayerEditor.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoPlayerEditor.cs
@@ -21,6 +21,7 @@ namespace Vimeo
         {
             GameObject go = Instantiate(Resources.Load("Prefabs/[VimeoPlayerCanvas]") as GameObject);
             go.name = "[VimeoPlayerCanvas]";
+            go.GetComponent<VimeoPlayer>().audioSource = Camera.main.gameObject.AddComponent<AudioSource>();
         }
 
         [MenuItem("GameObject/Video/Vimeo Player (Plane)")]

--- a/Assets/Vimeo/Scripts/Editor/VimeoPlugin.cs
+++ b/Assets/Vimeo/Scripts/Editor/VimeoPlugin.cs
@@ -62,7 +62,6 @@ namespace Vimeo
             BuildTargetGroup.Nintendo3DS,
 #endif
             BuildTargetGroup.PS4,
-            BuildTargetGroup.PSP2,
             BuildTargetGroup.Standalone,
             BuildTargetGroup.tvOS,
             BuildTargetGroup.XboxOne


### PR DESCRIPTION
- [x] Fix `CanvasPlayer` so the `AudioSource` is not attached to a `RectTransform` object (fixes #85)
- [x] Get rid of `PS2` as a build target (fixes #82)

Tested against:
- [x] `2019.1.0f1`
- [x] `2018.2.14f1`
- [x] `2017.1.5f1`