### PR TITLE
Add OnVideoFinish event to the VimeoPlayer

### DIFF
--- a/Assets/Vimeo/Scripts/Player/VideoController.cs
+++ b/Assets/Vimeo/Scripts/Player/VideoController.cs
@@ -12,6 +12,7 @@ namespace Vimeo.Player
 
         public delegate void PlaybackAction(VideoController controller);
         public event PlaybackAction OnVideoStart;
+        public event PlaybackAction OnVideoFinish;
         public event PlaybackAction OnPause;
         public event PlaybackAction OnPlay;
         public event PlaybackAction OnFrameReady;
@@ -68,6 +69,7 @@ namespace Vimeo.Player
                     videoPlayer.prepareCompleted += VideoPlayerStarted;
                     videoPlayer.seekCompleted += VideoSeekCompleted;
                     videoPlayer.frameReady += VideoFrameReady;
+                    videoPlayer.loopPointReached += VideoPlayerFinished;
 
                     videoPlayer.isLooping = true;
 
@@ -234,6 +236,13 @@ namespace Vimeo.Player
             }
 
             StartCoroutine("WaitForRenderTexture");
+        }
+
+        private void VideoPlayerFinished(VideoPlayer source)
+        {
+            if (OnVideoFinish != null) {
+                OnVideoFinish(this);
+            }
         }
 
         private void VideoSeekCompleted(VideoPlayer source)

--- a/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
+++ b/Assets/Vimeo/Scripts/Player/VimeoPlayer.cs
@@ -18,6 +18,7 @@ namespace Vimeo.Player
         public event VimeoEvent OnStart;
         public event VimeoEvent OnVideoMetadataLoad;
         public event VimeoEvent OnVideoStart;
+        public event VimeoEvent OnVideoFinish;
         public event VimeoEvent OnPause;
         public event VimeoEvent OnPlay;
         public event VimeoEvent OnFrameReady;
@@ -113,6 +114,7 @@ namespace Vimeo.Player
                     controller.videoScreenObject = videoScreen;
 
                     controller.OnVideoStart += VideoStarted;
+                    controller.OnVideoFinish += VideoFinished;
                     controller.OnPlay += VideoPlay;
                     controller.OnPause += VideoPaused;
                     controller.OnFrameReady += VideoFrameReady;
@@ -331,6 +333,13 @@ namespace Vimeo.Player
 
             if (OnVideoStart != null) {
                 OnVideoStart();
+            }
+        }
+
+        private void VideoFinished(VideoController controller)
+        {
+            if (OnVideoFinish != null) {
+                OnVideoFinish();
             }
         }
 


### PR DESCRIPTION
Solves [#125](https://github.com/vimeo/vimeo-unity-sdk/issues/125) by adding an `OnVideoFinish` event to the VimeoPlayer

Tested against:

- 2021.1.3f1
- 2020.3.4f1
- 2019.4.24f1
- 2018.4.34f1